### PR TITLE
print the error message of upgrade command

### DIFF
--- a/main.go
+++ b/main.go
@@ -173,9 +173,9 @@ func choose(modules []Module) []Module {
 func update(modules []Module) {
 	for _, x := range modules {
 		fmt.Fprintf(color.Output, "Updating %s to version %s...\n", formatName(x, len(x.name)), formatTo(x))
-		err := exec.Command("go", "get", x.name).Run()
+		out, err := exec.Command("go", "get", x.name).CombinedOutput()
 		if err != nil {
-			fmt.Printf("Error while updating %s: %v\n", x.name, err)
+			fmt.Printf("Error while updating %s: %s\n", x.name, string(out))
 		}
 	}
 }


### PR DESCRIPTION
Error message when upgrading a module, is meaningless. Just like `exit status 1` as shown below,

```
ζ go-mod-upgrade                                                                                                                                                                                                                 
Discovering modules...
? Choose which modules to update xxx/xxx/xxx                      0.0.66 -> 0.0.87,  xxx/xxx/xxx                      0.0.8  -> 0.0.9
Updating xxx/xxx/xxx to version 0.0.87...
Error while updating xxx/xxx/xxx: exit status 1
Updating xxx/xxx/xxx to version 0.0.9...
```

So let it print out the real error message but not the the code that the command returned.

```
ζ go-mod-upgrade                                                                                                                                                                                                                
Discovering modules...
? Choose which modules to update xxx/xxx/xxx                        0.0.66 -> 0.0.87, xxx/xxx/xxx                      0.0.8  -> 0.0.9
Updating xxx/xxx/xxx to version 0.0.87...
Error while updating xxx/xxx/xxx: go: xxx/xxx/xxx upgrade => v0.0.87
go: go.etcd.io/etcd@v0.0.0-20200401174654-e694b7bb0875 used for two different module paths (github.com/coreos/etcd and go.etcd.io/etcd)

Updating xxx/xxx/xxx to version 0.0.9...
```