### PR TITLE
chore: add github action for golang

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.2
+          go-version: "^1.15"
       - run: go test -race ./...
   build-gotip:
     name: Build
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16.2
+          go-version: "^1.15"
       - run: go build
   lint:
     name: Lint
@@ -28,4 +28,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: latest
+          version: v1.28

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -14,7 +14,7 @@ jobs:
       - run: go test -race ./...
   build-gotip:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -23,7 +23,7 @@ jobs:
       - run: go build
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -12,9 +12,12 @@ jobs:
         with:
           go-version: "^1.15"
       - run: go test -race ./...
-  build-gotip:
+  build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-11.0, macos-10.15, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.15"
+          go-version: "~1.15"
       - run: go test -race ./...
   build:
     name: Build
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "^1.15"
+          go-version: "~1.15"
       - run: go build
   lint:
     name: Lint

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,31 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+      - run: go test -race ./...
+  build-gotip:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+      - run: go build
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: golangci/golangci-lint-action@v2
+        with:
+          version: latest

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11.0, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-
-go:
-  - 1.15.x
-
-script:
-  - make lint


### PR DESCRIPTION
- [x] Remove `.travis.yml`
- [x] Use latest go version 1.15.x as possible
- [x] Use golangci-lint version 1.28
- [x] Use Ubuntu 20.04 for testing and linting
- [x] Test building on Windows, MacOS

You can see github action running in my fork: https://github.com/haunt98/go-mod-upgrade/actions/runs/679138635