### PR TITLE
CLI flag to execute a hook for each updated module

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,7 @@ func update(modules []Module, hook string) {
 			out, err := exec.Command(hook, x.name, x.from.String(), x.to.String()).CombinedOutput()
 			if err != nil {
 				fmt.Printf("Error while executing hook %s: %s\n", hook, string(out))
+				os.Exit(1)
 			}
 			fmt.Println(string(out))
 		}

--- a/main.go
+++ b/main.go
@@ -190,12 +190,19 @@ func choose(modules []Module, pageSize int) []Module {
 	return updates
 }
 
-func update(modules []Module) {
+func update(modules []Module, hook string) {
 	for _, x := range modules {
 		fmt.Fprintf(color.Output, "Updating %s to version %s...\n", formatName(x, len(x.name)), formatTo(x))
 		out, err := exec.Command("go", "get", x.name).CombinedOutput()
 		if err != nil {
 			fmt.Printf("Error while updating %s: %s\n", x.name, string(out))
+		}
+		if hook != "" {
+			out, err := exec.Command(hook, x.name, x.from.String(), x.to.String()).CombinedOutput()
+			if err != nil {
+				fmt.Printf("Error while executing hook %s: %s\n", hook, string(out))
+			}
+			fmt.Println(string(out))
 		}
 	}
 }
@@ -205,6 +212,7 @@ func main() {
 		verbose  bool
 		force    bool
 		pageSize int
+		hook     string
 	)
 
 	cli.VersionFlag = &cli.BoolFlag{
@@ -247,6 +255,11 @@ func main() {
 				Usage:       "Verbose mode",
 				Destination: &verbose,
 			},
+			&cli.PathFlag{
+				Name:        "hook",
+				Usage:       "Hook to execute for each updated module",
+				Destination: &hook,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			modules, err := discover(verbose)
@@ -257,12 +270,12 @@ func main() {
 				if verbose {
 					fmt.Println("Update all modules in non-interactive mode...")
 				}
-				update(modules)
+				update(modules, hook)
 				return nil
 			}
 			if len(modules) > 0 {
 				modules = choose(modules, pageSize)
-				update(modules)
+				update(modules, hook)
 			} else {
 				fmt.Println("All modules are up to date")
 			}


### PR DESCRIPTION
This is a more general approach to what has been proposed in PR #13, as this allows to run external command for each updated module (not just git commit).

Here is an example hook to commit the changes (saved as _.git/hooks/commit.sh_):
```bash
#!/bin/sh

git add go.mod go.sum
git commit -m "chore(deps): bump $1 from $2 to $3"
```
![hook](https://user-images.githubusercontent.com/1004034/112304361-ae7b4380-8c9d-11eb-8477-80dffeb277f8.png)


