### PR TITLE
Add progress spinner

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/apex/log v1.9.0
+	github.com/briandowns/spinner v1.16.0
 	github.com/fatih/color v1.13.0
 	github.com/urfave/cli/v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
+github.com/briandowns/spinner v1.16.0 h1:DFmp6hEaIx2QXXuqSJmtfSBSAjRmpGiKG6ip2Wm/yOs=
+github.com/briandowns/spinner v1.16.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -9,12 +9,14 @@ import (
 	"regexp"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/AlecAivazis/survey/v2"
 	term "github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/Masterminds/semver/v3"
 	"github.com/apex/log"
 	logcli "github.com/apex/log/handlers/cli"
+	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 )
@@ -111,7 +113,10 @@ func (m MultiSelect) Cleanup(config *survey.PromptConfig, val interface{}) error
 }
 
 func discover() ([]Module, error) {
-	log.Info("Discovering modules...")
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s.Suffix = " Discovering modules..."
+	s.Start()
+
 	args := []string{
 		"list",
 		"-u",
@@ -121,10 +126,14 @@ func discover() ([]Module, error) {
 		"-m",
 		"all",
 	}
+
 	list, err := exec.Command("go", args...).Output()
+	s.Stop()
+
 	if err != nil {
 		return nil, fmt.Errorf("Error running go command to discover modules: %w", err)
 	}
+
 	split := strings.Split(string(list), "\n")
 	modules := []Module{}
 	re := regexp.MustCompile(`'(.+): (.+) -> (.+)'`)

--- a/main.go
+++ b/main.go
@@ -130,6 +130,9 @@ func discover() ([]Module, error) {
 	list, err := exec.Command("go", args...).Output()
 	s.Stop()
 
+	// Clear line
+	fmt.Printf("\r%s\r", strings.Repeat(" ", len(s.Suffix)+1))
+
 	if err != nil {
 		return nil, fmt.Errorf("Error running go command to discover modules: %w", err)
 	}


### PR DESCRIPTION
This PR adds a progress spinner to the module discovery process, and clears the line after it's done.

Using this utility on large projects can take quite some time, and led me to believe that something got stuck before, so I think having a progress indicator can help a lot in signaling that the process is still running.