### PR TITLE
only download the packages when updating

### DIFF
--- a/main.go
+++ b/main.go
@@ -291,7 +291,7 @@ func choose(modules []Module, pageSize int) []Module {
 func update(modules []Module, hook string) {
 	for _, x := range modules {
 		fmt.Fprintf(color.Output, "Updating %s to version %s...\n", formatName(x, len(x.name)), formatTo(x))
-		out, err := exec.Command("go", "get", x.name).CombinedOutput()
+		out, err := exec.Command("go", "get", "-d", x.name).CombinedOutput()
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,


### PR DESCRIPTION
> The -d flag instructs get to stop after downloading the packages; that is, it instructs get not to install the packages. 

This change will prevent the error below which is reproducible within this sample repository (https://github.com/alock/gmu-enhancement).

```shell
❯ go-mod-upgrade
   • Using directory           dir=/github/alock/gmu-enhancement
Updating github.com/jedib0t/go-pretty/v6 to version 6.3.5...
   ⨯ Error while updating module error=exit status 1 name=github.com/jedib0t/go-pretty/v6 out=go build github.com/jedib0t/go-pretty/v6: no non-test Go files in /go/pkg/mod/github.com/jedib0t/go-pretty/v6@v6.3.5
 ```