### PR TITLE
github actions improvements

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.28
+          version: v1.47
   goreleaser:
     name: Release
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ golangci-lint = ./bin/golangci-lint
 goreleaser = ./bin/goreleaser
 
 $(golangci-lint):
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.28.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.47.3
 
 $(goreleaser):
 	curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh


### PR DESCRIPTION
* update to the latest version of golangci-lint which works with golang 1.18 better
* remove deprecated mac environment