### PR TITLE
Don't stop at first path when `force` flag is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,13 +172,12 @@ func (app *appEnv) run() error {
 		if err != nil {
 			return err
 		}
-		if app.force {
-			log.Debug("Update all modules in non-interactive mode...")
-			update(modules, app.hook)
-			return nil
-		}
 		if len(modules) > 0 {
-			modules = choose(modules, app.pageSize)
+			if app.force {
+				log.Debug("Update all modules in non-interactive mode...")
+			} else {
+				modules = choose(modules, app.pageSize)
+			}
 			update(modules, app.hook)
 		} else {
 			fmt.Println("All modules are up to date")


### PR DESCRIPTION
When the `force` flag is set and the app has several paths, the current script `return` after the first update, and prevents other paths to be updated.