### PR TITLE
feat: display new release age

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.5.0
 	github.com/apex/log v1.9.0
 	github.com/briandowns/spinner v1.23.2
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.19.0
 	github.com/urfave/cli/v3 v3.9.0
 	golang.org/x/mod v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,12 +1,14 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -44,9 +46,10 @@ type AppEnv struct {
 	PageSize int
 	Hook     string
 	Ignore   []string
+	ShowAge  bool
 }
 
-func (app *AppEnv) Run() error {
+func (app *AppEnv) Run(ctx context.Context) error {
 	if app.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}
@@ -111,6 +114,9 @@ func (app *AppEnv) Run() error {
 			modules = append(modules, toolModules...)
 		}
 		if len(modules) > 0 {
+			if app.ShowAge {
+				fetchReleaseDates(ctx, modules)
+			}
 			if app.List {
 				listModules(modules)
 			} else if app.Force {
@@ -335,13 +341,15 @@ func shouldIgnore(name, from, to string, ignoreNames []string) bool {
 func listModules(modules []module.Module) {
 	maxName := 0
 	maxFrom := 0
+	maxTo := 0
 	for _, x := range modules {
 		maxName = max(maxName, len(x.Name))
 		maxFrom = max(maxFrom, len(x.From.String()))
+		maxTo = max(maxTo, len(x.To.String()))
 	}
 	for _, x := range modules {
 		from := x.FormatFrom(maxFrom)
-		_, err := fmt.Fprintf(color.Output, "%s %s -> %s\n", x.FormatName(maxName), from, x.FormatTo())
+		_, err := fmt.Fprintf(color.Output, "%s %s -> %s  %s\n", x.FormatName(maxName), from, x.FormatTo(maxTo), x.FormatAge())
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -354,14 +362,16 @@ func listModules(modules []module.Module) {
 func choose(modules []module.Module, pageSize int) []module.Module {
 	maxName := 0
 	maxFrom := 0
+	maxTo := 0
 	for _, x := range modules {
 		maxName = max(maxName, len(x.Name))
 		maxFrom = max(maxFrom, len(x.From.String()))
+		maxTo = max(maxTo, len(x.To.String()))
 	}
 	options := []string{}
 	for _, x := range modules {
 		from := x.FormatFrom(maxFrom)
-		option := fmt.Sprintf("%s %s -> %s", x.FormatName(maxName), from, x.FormatTo())
+		option := fmt.Sprintf("%s %s -> %s  %s", x.FormatName(maxName), from, x.FormatTo(maxTo), x.FormatAge())
 		options = append(options, option)
 	}
 	prompt := &MultiSelect{
@@ -389,7 +399,7 @@ func choose(modules []module.Module, pageSize int) []module.Module {
 
 func update(modules []module.Module, hook string) {
 	for _, x := range modules {
-		_, err := fmt.Fprintf(color.Output, "Updating %s to version %s...\n", x.FormatName(len(x.Name)), x.FormatTo())
+		_, err := fmt.Fprintf(color.Output, "Updating %s to version %s...\n", x.FormatName(len(x.Name)), x.FormatTo(0))
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -422,4 +432,35 @@ func update(modules []module.Module, hook string) {
 			log.Info(string(out))
 		}
 	}
+}
+
+var proxyClient = NewClient()
+
+func fetchReleaseDates(ctx context.Context, modules []module.Module) {
+	work := make(chan int, len(modules))
+	var wg sync.WaitGroup
+
+	for range 10 {
+		wg.Go(func() {
+			for i := range work {
+				t, err := proxyClient.GetVersionTime(ctx, modules[i].Name, "v"+modules[i].To.String())
+				if err != nil {
+					log.WithFields(log.Fields{
+						"module":  modules[i].Name,
+						"version": modules[i].To.String(),
+						"error":   err,
+					}).Debug("Failed to fetch release date")
+					continue
+				}
+				modules[i].Date = t
+			}
+		})
+	}
+
+	for i := range modules {
+		work <- i
+	}
+	close(work)
+
+	wg.Wait()
 }

--- a/internal/app/proxy.go
+++ b/internal/app/proxy.go
@@ -1,0 +1,209 @@
+// This file is derived from github.com/fchimpan/gomod-age, used under the MIT license.
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const defaultGOPROXY = "https://proxy.golang.org,direct"
+
+// proxyEntry represents a single entry in the GOPROXY chain.
+type proxyEntry struct {
+	url         string // empty for "direct"
+	isDirect    bool
+	fallbackAll bool // true if separated by '|' (fall through on any error)
+}
+
+// Client queries Go module proxies following the GOPROXY chain.
+type Client struct {
+	entries    []proxyEntry
+	httpClient *http.Client
+}
+
+type Option func(*Client)
+
+func NewClient(opts ...Option) *Client {
+	c := &Client{
+		entries:    parseGOPROXY(os.Getenv("GOPROXY")),
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+type versionInfo struct {
+	Version string    `json:"Version"`
+	Time    time.Time `json:"Time"`
+}
+
+// GetVersionTime queries the GOPROXY chain for the publish time of a module version.
+// Follows Go's GOPROXY protocol:
+//   - comma separator: fall through to next proxy on 404/410 only
+//   - pipe separator: fall through on any error
+//   - "direct": skip (we cannot query VCS directly for .info)
+//   - "off": stop
+func (c *Client) GetVersionTime(ctx context.Context, modulePath, version string) (time.Time, error) {
+	encoded := encodePath(modulePath)
+	encodedVersion := encodePath(version)
+
+	var lastErr error
+	for _, entry := range c.entries {
+		if entry.isDirect {
+			lastErr = fmt.Errorf("module %s@%s not available via proxy (requires direct VCS access)", modulePath, version)
+			continue
+		}
+
+		t, err := c.queryProxy(ctx, entry.url, encoded, encodedVersion, modulePath, version)
+		if err == nil {
+			return t, nil
+		}
+
+		lastErr = err
+
+		// Determine whether to try next proxy
+		if entry.fallbackAll {
+			// pipe separator: fall through on any error
+			continue
+		}
+		// comma separator: fall through only on 404/410
+		if isNotFound(err) {
+			continue
+		}
+		// Other errors (5xx, timeout, etc.): stop
+		return time.Time{}, err
+	}
+
+	if lastErr != nil {
+		return time.Time{}, lastErr
+	}
+	return time.Time{}, fmt.Errorf("no proxy configured for %s@%s", modulePath, version)
+}
+
+// proxyError wraps an HTTP error with the status code for fallback decisions.
+type proxyError struct {
+	statusCode int
+	msg        string
+}
+
+func (e *proxyError) Error() string { return e.msg }
+
+func isNotFound(err error) bool {
+	if pe, ok := err.(*proxyError); ok {
+		return pe.statusCode == http.StatusNotFound || pe.statusCode == http.StatusGone
+	}
+	return false
+}
+
+func (c *Client) queryProxy(ctx context.Context, baseURL, encodedPath, encodedVersion, modulePath, version string) (time.Time, error) {
+	url := fmt.Sprintf("%s/%s/@v/%s.info", baseURL, encodedPath, encodedVersion)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("creating request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("querying proxy %s: %w", baseURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return time.Time{}, &proxyError{
+			statusCode: resp.StatusCode,
+			msg:        fmt.Sprintf("proxy %s returned %s for %s@%s", baseURL, resp.Status, modulePath, version),
+		}
+	}
+
+	var info versionInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return time.Time{}, fmt.Errorf("decoding response from %s: %w", baseURL, err)
+	}
+
+	if info.Time.IsZero() {
+		return time.Time{}, fmt.Errorf("proxy %s returned no publish time for %s@%s", baseURL, modulePath, version)
+	}
+
+	return info.Time, nil
+}
+
+// parseGOPROXY parses the GOPROXY environment variable into a chain of entries.
+func parseGOPROXY(goproxy string) []proxyEntry {
+	if goproxy == "" {
+		goproxy = defaultGOPROXY
+	}
+
+	var entries []proxyEntry
+	remaining := goproxy
+
+	for remaining != "" {
+		var raw string
+		fallbackAll := false
+
+		// Find the next separator
+		commaIdx := strings.Index(remaining, ",")
+		pipeIdx := strings.Index(remaining, "|")
+
+		switch {
+		case commaIdx < 0 && pipeIdx < 0:
+			// Last entry
+			raw = remaining
+			remaining = ""
+		case pipeIdx >= 0 && (commaIdx < 0 || pipeIdx < commaIdx):
+			// Pipe separator comes first
+			raw = remaining[:pipeIdx]
+			remaining = remaining[pipeIdx+1:]
+			fallbackAll = true
+		default:
+			// Comma separator comes first
+			raw = remaining[:commaIdx]
+			remaining = remaining[commaIdx+1:]
+			fallbackAll = false
+		}
+
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+
+		if raw == "off" {
+			break
+		}
+
+		if raw == "direct" {
+			entries = append(entries, proxyEntry{isDirect: true, fallbackAll: fallbackAll})
+			continue
+		}
+
+		entries = append(entries, proxyEntry{
+			url:         strings.TrimRight(raw, "/"),
+			fallbackAll: fallbackAll,
+		})
+	}
+
+	return entries
+}
+
+// encodePath encodes a module path or version for use in proxy URLs.
+// Uppercase letters are replaced with '!' followed by the lowercase letter.
+func encodePath(path string) string {
+	var b strings.Builder
+	for _, r := range path {
+		if unicode.IsUpper(r) {
+			b.WriteByte('!')
+			b.WriteRune(unicode.ToLower(r))
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
 )
 
@@ -20,6 +22,7 @@ type Module struct {
 	Name string
 	From *semver.Version
 	To   *semver.Version
+	Date time.Time
 }
 
 func (mod *Module) FormatName(length int) string {
@@ -41,7 +44,7 @@ func (mod *Module) FormatFrom(length int) string {
 	return c(padRight(mod.From.String(), length))
 }
 
-func (mod *Module) FormatTo() string {
+func (mod *Module) FormatTo(length int) string {
 	green := color.New(color.FgGreen).SprintFunc()
 	var buf bytes.Buffer
 	from := mod.From
@@ -70,5 +73,16 @@ func (mod *Module) FormatTo() string {
 	if to.Metadata() != "" {
 		fmt.Fprintf(&buf, "%s%s", green("+"), green(to.Metadata()))
 	}
+	if need := length - len(mod.To.String()); need > 0 {
+		buf.WriteString(strings.Repeat(" ", need))
+	}
 	return buf.String()
+}
+
+func (mod *Module) FormatAge() string {
+	if mod.Date.IsZero() {
+		return ""
+	}
+	c := color.New(color.FgHiBlack).SprintFunc()
+	return c(humanize.RelTime(mod.Date, time.Now(), "old", "from now"))
 }

--- a/main.go
+++ b/main.go
@@ -90,6 +90,12 @@ func main() {
 				Usage:       "Verbose mode",
 				Destination: &app.Verbose,
 			},
+			&cli.BoolFlag{
+				Name:        "show-age",
+				Value:       false,
+				Usage:       "Show package release age",
+				Destination: &app.ShowAge,
+			},
 			&cli.StringFlag{
 				Name:        "hook",
 				Usage:       "Hook to execute for each updated module",
@@ -104,7 +110,7 @@ func main() {
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			return app.Run()
+			return app.Run(ctx)
 		},
 		UseShortOptionHandling: true,
 		EnableShellCompletion:  true,


### PR DESCRIPTION
One of the easiest ways to mitigate supply chain attacks is to simply delay adoption of new package releases. Tools like [gomod-age](https://github.com/fchimpan/gomod-age) make it easy to review the age of all current packages, but upgrading with a minimum age policy is a manual process.

It would be good if `go-mod-upgrade` could display the age of new releases. This is the first step towards a bigger feature - the ability to specify a minimum package age that actually filters the releases presented.

Go proxy client code has been borrowed from `gomod-age` but is simple enough to rewrite if preferred.
Same with humanize, a simple age formatter could be written to avoid the new dependency.