### PR TITLE
feat: add a --cooldown flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ _When upgrading: major version updates are now offered by default, and accepting
 ### Added
 
 - Add `--no-major` flag to disable major version checking, and `--no-cache` to skip the 24-hour disk cache the lookups use ([#69](https://github.com/oligot/go-mod-upgrade/pull/69))
+- Add `--cooldown` flag to only consider versions published at least a given period ago, lowering the offered version or holding the module back when the latest is too new ([#76](https://github.com/oligot/go-mod-upgrade/pull/76))
 
 ## [0.12.0] - 2025-09-21
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fatih/color"
 	"golang.org/x/mod/modfile"
 
+	"github.com/oligot/go-mod-upgrade/internal/cooldown"
 	"github.com/oligot/go-mod-upgrade/internal/discover"
 	"github.com/oligot/go-mod-upgrade/internal/module"
 	"github.com/oligot/go-mod-upgrade/internal/prompt"
@@ -29,6 +30,7 @@ type AppEnv struct {
 	Ignore   []string
 	NoMajor  bool
 	NoCache  bool
+	Cooldown string
 }
 
 func (app *AppEnv) Run() error {
@@ -38,6 +40,14 @@ func (app *AppEnv) Run() error {
 	ignore, err := discover.CompileIgnore(app.Ignore)
 	if err != nil {
 		return err
+	}
+	var window time.Duration
+	if app.Cooldown != "" {
+		window, err = cooldown.ParseDuration(app.Cooldown)
+		if err != nil {
+			return err
+		}
+		log.WithField("cooldown", window).Debug("Cooldown window")
 	}
 	// Deliberately not routed through discover.Exec: that sets GOWORK=off,
 	// which would make this always report "off" and break workspace detection.
@@ -57,7 +67,7 @@ func (app *AppEnv) Run() error {
 			dir = filepath.Join(filepath.Dir(gowork), path)
 		}
 		log.WithField("dir", dir).Info("Using directory")
-		if err := app.runDir(dir, ignore); err != nil {
+		if err := app.runDir(dir, ignore, window); err != nil {
 			// Ctrl+C means stop the whole walk, not just this module: handle
 			// the abort here rather than inside runDir.
 			if errors.Is(err, prompt.ErrAborted) {
@@ -99,7 +109,7 @@ func workspacePaths(gowork string) ([]string, error) {
 }
 
 // runDir discovers and updates the modules of one module directory.
-func (app *AppEnv) runDir(dir string, ignore []*regexp.Regexp) error {
+func (app *AppEnv) runDir(dir string, ignore []*regexp.Regexp, window time.Duration) error {
 	d := discover.Discoverer{Run: discover.Exec, Dir: dir, Ignore: ignore}
 	found, err := withSpinner(" Discovering modules...", func() (discovered, error) {
 		modules, err := d.Modules()
@@ -138,8 +148,18 @@ func (app *AppEnv) runDir(dir string, ignore []*regexp.Regexp) error {
 		modules = append(modules, toolModules...)
 	}
 
+	var held []cooldown.Held
+	if window > 0 {
+		modules, held = cooldown.Filter(modules, window, time.Now(), d.Versions)
+		printHeld(held, window)
+	}
+
 	if len(modules) == 0 {
-		fmt.Println("All modules are up to date")
+		// Everything held back by cooldown is not the same as everything being
+		// up to date, and printHeld has already said so.
+		if len(held) == 0 {
+			fmt.Println("All modules are up to date")
+		}
 		return nil
 	}
 	if app.List {
@@ -183,11 +203,37 @@ func withSpinner[T any](suffix string, fn func() (T, error)) (T, error) {
 	return result, err
 }
 
+// printHeld reports the modules whose updates the cooldown window withheld, so
+// that they don't disappear from the output silently.
+func printHeld(held []cooldown.Held, window time.Duration) {
+	if len(held) == 0 {
+		return
+	}
+	plural := "s"
+	if len(held) == 1 {
+		plural = ""
+	}
+	c := color.New(color.FgYellow).SprintFunc()
+	header := fmt.Sprintf("%d module%s held back by cooldown (%s):", len(held), plural, module.FormatAge(window))
+	if _, err := fmt.Fprintf(color.Output, "%s\n", c(header)); err != nil {
+		log.WithError(err).Error("Error while printing held back modules")
+		return
+	}
+	for _, h := range held {
+		if _, err := fmt.Fprintf(color.Output, "  %s %s (%s old)\n", h.Name, h.Version, module.FormatAge(h.Age)); err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+				"name":  h.Name,
+			}).Error("Error while printing held back module")
+		}
+	}
+}
+
 func listModules(modules []module.Module) {
 	maxName, maxFrom := module.MaxWidths(modules)
 	for _, x := range modules {
 		from := x.FormatFrom(maxFrom)
-		_, err := fmt.Fprintf(color.Output, "%s %s -> %s\n", x.FormatName(maxName), from, x.FormatTo())
+		_, err := fmt.Fprintf(color.Output, "%s %s -> %s%s\n", x.FormatName(maxName), from, x.FormatTo(), x.FormatCooldown())
 		if err != nil {
 			log.WithFields(log.Fields{
 				"error": err,
@@ -215,9 +261,10 @@ func update(dir string, modules []module.Module, hook string) error {
 				"name":  x.Name,
 			}).Error("Error while updating module")
 		}
-		// The version is pinned rather than left to `go get <module>`: a major
-		// upgrade resolves to a different module path, and the bare form would
-		// pick that path's latest rather than the version offered.
+		// The version is pinned rather than left to `go get <module>`: the bare
+		// form means @upgrade, which resolves to that path's latest — a
+		// different module path after a major upgrade, and the very version
+		// cooldown withheld otherwise.
 		target := x.Name + "@" + x.To.Original()
 		if out, err := runGo(dir, "get", target); err != nil {
 			return fmt.Errorf("go get %s: %w: %s", target, err, strings.TrimSpace(string(out)))

--- a/internal/cooldown/cooldown.go
+++ b/internal/cooldown/cooldown.go
@@ -1,0 +1,153 @@
+// Package cooldown withholds module versions that were published too recently.
+package cooldown
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/apex/log"
+	"github.com/oligot/go-mod-upgrade/internal/module"
+)
+
+// ParseDuration parses a cooldown period. A bare number is a number of days; a
+// number may also carry a d, h or m suffix.
+func ParseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, errors.New("empty cooldown period")
+	}
+	digits := s
+	unit := 24 * time.Hour
+	switch s[len(s)-1] {
+	case 'd':
+		digits = s[:len(s)-1]
+	case 'h':
+		digits = s[:len(s)-1]
+		unit = time.Hour
+	case 'm':
+		digits = s[:len(s)-1]
+		unit = time.Minute
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, fmt.Errorf("invalid cooldown period %q: expected a number of days or a value like 7d, 12h or 30m", s)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("invalid cooldown period %q: must not be negative", s)
+	}
+	return time.Duration(n) * unit, nil
+}
+
+// VersionInfo is a candidate module version and the time it was published.
+type VersionInfo struct {
+	Version *semver.Version
+	Time    time.Time
+}
+
+// Lookup reports the tagged versions of a module newer than after, in ascending
+// order, together with their publish times.
+type Lookup func(name string, after *semver.Version) ([]VersionInfo, error)
+
+// Held is a module whose update was withheld entirely by the cooldown window.
+type Held struct {
+	Name    string
+	Version *semver.Version
+	Age     time.Duration
+}
+
+// Filter applies the cooldown window to mods. A module whose target version is
+// too recent falls back to the greatest version old enough to satisfy the
+// window. Modules with no such version, and modules whose versions can't be
+// checked, are removed from the returned modules and reported as held back.
+func Filter(mods []module.Module, window time.Duration, now time.Time, lookup Lookup) ([]module.Module, []Held) {
+	if window <= 0 {
+		return mods, nil
+	}
+	kept := []module.Module{}
+	held := []Held{}
+	for _, mod := range mods {
+		// go list omits the publish time when it can't determine it, leaving
+		// ToTime at the zero value. Subtracting it would yield an age of two
+		// millennia and wave the version through unverified, so treat an unknown
+		// time as an age of zero and let the lookup path decide: fail closed.
+		known := !mod.ToTime.IsZero()
+		var age time.Duration
+		if known {
+			age = now.Sub(mod.ToTime)
+		}
+		if known && age >= window {
+			kept = append(kept, mod)
+			continue
+		}
+		log.WithFields(log.Fields{
+			"name":    mod.Name,
+			"version": mod.To.String(),
+			"age":     age,
+			"window":  window,
+		}).Debug("Version is within the cooldown window")
+		candidates, err := lookup(mod.Name, mod.From)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error": err,
+				"name":  mod.Name,
+			}).Warn("Couldn't check versions, holding module back")
+			held = append(held, Held{Name: mod.Name, Version: mod.To, Age: age})
+			continue
+		}
+		fallback, ok := greatestOldEnough(mod, candidates, window, now)
+		if !ok {
+			log.WithFields(log.Fields{
+				"name": mod.Name,
+			}).Debug("No version satisfies the cooldown window, holding module back")
+			held = append(held, Held{Name: mod.Name, Version: mod.To, Age: age})
+			continue
+		}
+		log.WithFields(log.Fields{
+			"name": mod.Name,
+			"held": mod.To.String(),
+			"use":  fallback.Version.String(),
+		}).Debug("Falling back to an earlier version")
+		mod.Cooldown = &module.Cooldown{Version: mod.To, Age: age}
+		mod.To = fallback.Version
+		mod.ToTime = fallback.Time
+		kept = append(kept, mod)
+	}
+	return kept, held
+}
+
+// greatestOldEnough returns the highest candidate that is an upgrade for mod,
+// lower than its current target, and published at least window ago.
+func greatestOldEnough(mod module.Module, candidates []VersionInfo, window time.Duration, now time.Time) (VersionInfo, bool) {
+	for i := len(candidates) - 1; i >= 0; i-- {
+		candidate := candidates[i]
+		if !candidate.Version.GreaterThan(mod.From) || !candidate.Version.LessThan(mod.To) {
+			continue
+		}
+		// go list -m -versions does list prerelease tags, and semver orders
+		// v1.4.0-rc.1 below v1.4.0. Offering one to a user on a stable version
+		// would introduce an upgrade go list -u would never propose, so only stay
+		// on a prerelease line the module is already on.
+		if candidate.Version.Prerelease() != "" && mod.From.Prerelease() == "" {
+			log.WithFields(log.Fields{
+				"name":    mod.Name,
+				"version": candidate.Version.String(),
+			}).Debug("Skipping prerelease version")
+			continue
+		}
+		if candidate.Time.IsZero() {
+			log.WithFields(log.Fields{
+				"name":    mod.Name,
+				"version": candidate.Version.String(),
+			}).Debug("No publish time for version, skipping")
+			continue
+		}
+		if now.Sub(candidate.Time) >= window {
+			return candidate, true
+		}
+	}
+	return VersionInfo{}, false
+}

--- a/internal/cooldown/cooldown_test.go
+++ b/internal/cooldown/cooldown_test.go
@@ -1,0 +1,312 @@
+package cooldown
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oligot/go-mod-upgrade/internal/module"
+)
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"bare number means days", "7", 7 * 24 * time.Hour, false},
+		{"days suffix", "7d", 7 * 24 * time.Hour, false},
+		{"hours suffix", "12h", 12 * time.Hour, false},
+		{"minutes suffix", "30m", 30 * time.Minute, false},
+		{"zero is valid", "0", 0, false},
+		{"surrounding space", " 7d ", 7 * 24 * time.Hour, false},
+		{"empty", "", 0, true},
+		{"not a number", "x", 0, true},
+		{"negative", "-1", 0, true},
+		{"unknown suffix", "7w", 0, true},
+		{"fractional", "1.5d", 0, true},
+		{"suffix only", "d", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseDuration(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseDuration(%q) = %s, want an error", tt.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDuration(%q) returned unexpected error: %v", tt.in, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseDuration(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// fixedNow is an arbitrary but fixed clock, so ages in tests are exact.
+var fixedNow = time.Date(2026, 7, 26, 12, 0, 0, 0, time.UTC)
+
+// testModule builds a module whose target version was published age ago.
+func testModule(name, from, to string, age time.Duration) module.Module {
+	return module.Module{
+		Name:   name,
+		From:   semver.MustParse(from),
+		To:     semver.MustParse(to),
+		ToTime: fixedNow.Add(-age),
+	}
+}
+
+// fakeLookup returns canned versions and counts how often it was called.
+type fakeLookup struct {
+	versions map[string][]VersionInfo
+	err      error
+	calls    int
+}
+
+func (f *fakeLookup) lookup(name string, after *semver.Version) ([]VersionInfo, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.versions[name], nil
+}
+
+// version builds a VersionInfo published age ago.
+func version(v string, age time.Duration) VersionInfo {
+	return VersionInfo{Version: semver.MustParse(v), Time: fixedNow.Add(-age)}
+}
+
+const week = 7 * 24 * time.Hour
+
+func TestFilterKeepsModulesOlderThanTheWindow(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.0.0", "v1.1.0", 30*24*time.Hour)}
+	f := &fakeLookup{}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(kept) != 1 || kept[0].To.String() != "1.1.0" {
+		t.Fatalf("kept = %v, want the module unchanged at 1.1.0", kept)
+	}
+	if kept[0].Cooldown != nil {
+		t.Errorf("Cooldown = %v, want nil for an unaffected module", kept[0].Cooldown)
+	}
+	if len(held) != 0 {
+		t.Errorf("held = %v, want none", held)
+	}
+	if f.calls != 0 {
+		t.Errorf("lookup was called %d times, want 0 for the fast path", f.calls)
+	}
+}
+
+func TestFilterFallsBackToGreatestVersionOldEnough(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.0.0", "v1.4.0", 2*24*time.Hour)}
+	f := &fakeLookup{versions: map[string][]VersionInfo{
+		"example.com/a": {
+			version("v1.1.0", 60*24*time.Hour),
+			version("v1.2.0", 30*24*time.Hour),
+			version("v1.3.0", 3*24*time.Hour), // still inside the window
+			version("v1.4.0", 2*24*time.Hour),
+		},
+	}}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(held) != 0 {
+		t.Fatalf("held = %v, want none", held)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("kept = %v, want 1 module", kept)
+	}
+	if kept[0].To.String() != "1.2.0" {
+		t.Errorf("To = %s, want the greatest version older than the window, 1.2.0", kept[0].To)
+	}
+	if kept[0].ToTime != fixedNow.Add(-30*24*time.Hour) {
+		t.Errorf("ToTime = %s, want the publish time of 1.2.0", kept[0].ToTime)
+	}
+	if kept[0].Cooldown == nil {
+		t.Fatal("Cooldown = nil, want the withheld version recorded")
+	}
+	if kept[0].Cooldown.Version.String() != "1.4.0" {
+		t.Errorf("Cooldown.Version = %s, want 1.4.0", kept[0].Cooldown.Version)
+	}
+	if kept[0].Cooldown.Age != 2*24*time.Hour {
+		t.Errorf("Cooldown.Age = %s, want 48h", kept[0].Cooldown.Age)
+	}
+}
+
+func TestFilterHoldsBackWhenNoVersionIsOldEnough(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.0.0", "v1.1.0", 2*24*time.Hour)}
+	f := &fakeLookup{versions: map[string][]VersionInfo{
+		"example.com/a": {version("v1.1.0", 2*24*time.Hour)},
+	}}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(kept) != 0 {
+		t.Errorf("kept = %v, want none", kept)
+	}
+	if len(held) != 1 {
+		t.Fatalf("held = %v, want 1 module", held)
+	}
+	if held[0].Name != "example.com/a" || held[0].Version.String() != "1.1.0" {
+		t.Errorf("held[0] = %+v, want example.com/a at 1.1.0", held[0])
+	}
+	if held[0].Age != 2*24*time.Hour {
+		t.Errorf("held[0].Age = %s, want 48h", held[0].Age)
+	}
+}
+
+func TestFilterNeverFallsBackToTheCurrentVersionOrBelow(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.2.0", "v1.3.0", 2*24*time.Hour)}
+	f := &fakeLookup{versions: map[string][]VersionInfo{
+		"example.com/a": {
+			version("v1.1.0", 90*24*time.Hour),
+			version("v1.2.0", 60*24*time.Hour),
+			version("v1.3.0", 2*24*time.Hour),
+		},
+	}}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(kept) != 0 {
+		t.Errorf("kept = %v, want none: 1.2.0 is the current version and 1.1.0 is a downgrade", kept)
+	}
+	if len(held) != 1 {
+		t.Errorf("held = %v, want the module held back", held)
+	}
+}
+
+func TestFilterHoldsBackWhenLookupFails(t *testing.T) {
+	mods := []module.Module{
+		testModule("example.com/broken", "v1.0.0", "v1.1.0", time.Hour),
+		testModule("example.com/fine", "v2.0.0", "v2.1.0", 30*24*time.Hour),
+	}
+	f := &fakeLookup{err: errors.New("boom")}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(kept) != 1 || kept[0].Name != "example.com/fine" {
+		t.Errorf("kept = %v, want only example.com/fine", kept)
+	}
+	if len(held) != 1 || held[0].Name != "example.com/broken" {
+		t.Errorf("held = %v, want only example.com/broken", held)
+	}
+}
+
+func TestFilterSkipsVersionsWithoutAPublishTime(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.0.0", "v1.3.0", 2*24*time.Hour)}
+	f := &fakeLookup{versions: map[string][]VersionInfo{
+		"example.com/a": {
+			version("v1.1.0", 60*24*time.Hour),
+			{Version: semver.MustParse("v1.2.0")}, // zero Time
+			version("v1.3.0", 2*24*time.Hour),
+		},
+	}}
+
+	kept, _ := Filter(mods, week, fixedNow, f.lookup)
+
+	if len(kept) != 1 || kept[0].To.String() != "1.1.0" {
+		t.Errorf("kept = %v, want a fallback to 1.1.0, skipping the timestamp-less 1.2.0", kept)
+	}
+}
+
+func TestFilterHoldsBackWhenTheTargetPublishTimeIsUnknown(t *testing.T) {
+	// go list omits Time when it can't determine it, so ToTime decodes to the
+	// zero value. Subtracting it would yield an age of two millennia, waving the
+	// version through unverified; the contract is to fail closed instead.
+	mods := []module.Module{{
+		Name: "example.com/a",
+		From: semver.MustParse("v1.0.0"),
+		To:   semver.MustParse("v1.1.0"),
+	}}
+	f := &fakeLookup{versions: map[string][]VersionInfo{
+		"example.com/a": {version("v1.1.0", 60*24*time.Hour)},
+	}}
+
+	kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+	if f.calls != 1 {
+		t.Errorf("lookup was called %d times, want 1: an unknown publish time must not take the fast path", f.calls)
+	}
+	if len(kept) != 0 {
+		t.Errorf("kept = %v, want none: v1.1.0 is the target itself, so there is no lower fallback", kept)
+	}
+	if len(held) != 1 {
+		t.Fatalf("held = %v, want the module held back", held)
+	}
+	if held[0].Age != 0 {
+		t.Errorf("held[0].Age = %s, want 0 for an unknown publish time", held[0].Age)
+	}
+}
+
+func TestFilterFallbackAndPrereleases(t *testing.T) {
+	// go list -m -versions does list prerelease tags, and semver orders
+	// v1.4.0-rc.1 below v1.4.0, so a prerelease is a fallback candidate. Users on
+	// a stable version must not be offered one, since go list -u would never
+	// propose it either.
+	candidates := []VersionInfo{
+		version("v1.3.0", 60*24*time.Hour),
+		version("v1.4.0-rc.1", 30*24*time.Hour),
+		version("v1.4.0", 2*24*time.Hour),
+	}
+	tests := []struct {
+		name     string
+		from     string
+		to       string
+		wantTo   string
+		wantHeld bool
+	}{
+		{
+			name:     "a stable current version never falls back to a prerelease",
+			from:     "v1.3.0",
+			to:       "v1.4.0",
+			wantHeld: true,
+		},
+		{
+			name:   "a prerelease current version may move within the prerelease line",
+			from:   "v1.4.0-rc.0",
+			to:     "v1.4.0",
+			wantTo: "1.4.0-rc.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mods := []module.Module{testModule("example.com/a", tt.from, tt.to, 2*24*time.Hour)}
+			f := &fakeLookup{versions: map[string][]VersionInfo{"example.com/a": candidates}}
+
+			kept, held := Filter(mods, week, fixedNow, f.lookup)
+
+			if tt.wantHeld {
+				if len(kept) != 0 || len(held) != 1 {
+					t.Fatalf("kept = %v, held = %v, want the module held back", kept, held)
+				}
+				return
+			}
+			if len(held) != 0 {
+				t.Fatalf("held = %v, want none", held)
+			}
+			if len(kept) != 1 || kept[0].To.String() != tt.wantTo {
+				t.Fatalf("kept = %v, want a fallback to %s", kept, tt.wantTo)
+			}
+		})
+	}
+}
+
+func TestFilterIsANoOpWithoutAWindow(t *testing.T) {
+	mods := []module.Module{testModule("example.com/a", "v1.0.0", "v1.1.0", time.Minute)}
+	f := &fakeLookup{}
+
+	kept, held := Filter(mods, 0, fixedNow, f.lookup)
+
+	if len(kept) != 1 || kept[0].Cooldown != nil {
+		t.Errorf("kept = %v, want the module untouched", kept)
+	}
+	if len(held) != 0 || f.calls != 0 {
+		t.Errorf("held = %v, lookup calls = %d, want none of either", held, f.calls)
+	}
+}

--- a/internal/discover/parse.go
+++ b/internal/discover/parse.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/apex/log"
@@ -26,6 +27,7 @@ type goListModule struct {
 	Version  string
 	Main     bool
 	Indirect bool
+	Time     time.Time
 	Update   *goListModule
 }
 
@@ -60,9 +62,10 @@ func parseModules(out []byte, ignore []*regexp.Regexp) ([]module.Module, error) 
 			return nil, err
 		}
 		modules = append(modules, module.Module{
-			Name: name,
-			From: fromversion,
-			To:   toversion,
+			Name:   name,
+			From:   fromversion,
+			To:     toversion,
+			ToTime: listed.Update.Time,
 		})
 	}
 	return modules, nil

--- a/internal/discover/parse_test.go
+++ b/internal/discover/parse_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 // readFixture returns captured `go list` output.
@@ -33,6 +34,16 @@ func TestParseModulesFixture(t *testing.T) {
 	}
 	if got := modules[0].To.String(); got != "2.3.8" {
 		t.Errorf("first to = %q, want 2.3.8", got)
+	}
+	// The publish time of the update, not of the current version: cooldown
+	// falls back to an extra `go list` lookup for every module it is missing.
+	if got := modules[0].ToTime; !got.Equal(time.Date(2024, 2, 1, 10, 0, 0, 0, time.UTC)) {
+		t.Errorf("first toTime = %s, want 2024-02-01T10:00:00Z", got)
+	}
+	// go omits Time when it can't determine it; cooldown reads the zero value
+	// as unknown and checks that module the expensive way.
+	if got := modules[1].ToTime; !got.IsZero() {
+		t.Errorf("second toTime = %s, want the zero time", got)
 	}
 	for _, m := range modules {
 		if m.Name == "github.com/mattn/go-isatty" {

--- a/internal/discover/versions.go
+++ b/internal/discover/versions.go
@@ -1,0 +1,104 @@
+package discover
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/apex/log"
+
+	"github.com/oligot/go-mod-upgrade/internal/cooldown"
+)
+
+// Versions reports the tagged versions of a module newer than after, in
+// ascending order, together with their publish times. The method value
+// satisfies [cooldown.Lookup].
+func (d Discoverer) Versions(name string, after *semver.Version) ([]cooldown.VersionInfo, error) {
+	out, err := d.Run(d.Dir, "list", "-m", "-versions", name)
+	if err != nil {
+		return nil, fmt.Errorf("error listing versions of %s: %w", name, err)
+	}
+	newer, err := parseVersions(out, after)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing versions of %s: %w", name, err)
+	}
+	if len(newer) == 0 {
+		// No tagged version above the current one, for example a module resolved
+		// only through pseudo-versions. That is an expected state, not a failure:
+		// an empty candidate list holds the module back without a warning.
+		return nil, nil
+	}
+
+	queries := []string{"list", "-m", "-json"}
+	for _, v := range newer {
+		// Original preserves the v prefix, which is how go list reports versions.
+		queries = append(queries, name+"@"+v.Original())
+	}
+	timesOut, err := d.Run(d.Dir, queries...)
+	if err != nil {
+		return nil, fmt.Errorf("error looking up publish times of %s: %w", name, err)
+	}
+	times, err := parseTimes(timesOut)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing publish times of %s: %w", name, err)
+	}
+
+	versions := []cooldown.VersionInfo{}
+	for _, v := range newer {
+		versions = append(versions, cooldown.VersionInfo{Version: v, Time: times[v.Original()]})
+	}
+	return versions, nil
+}
+
+// parseVersions extracts from `go list -m -versions` output the versions above
+// after, in ascending order. Unparseable versions are skipped rather than
+// failing the lookup, and finding nothing newer is a normal outcome, not an
+// error.
+func parseVersions(out []byte, after *semver.Version) ([]*semver.Version, error) {
+	// The output is the module path followed by its versions.
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return nil, errors.New("no module path in go list -m -versions output")
+	}
+	name := fields[0]
+
+	newer := []*semver.Version{}
+	for _, field := range fields[1:] {
+		v, err := semver.NewVersion(field)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"name":    name,
+				"version": field,
+			}).Debug("Skipping unparseable version")
+			continue
+		}
+		if !v.GreaterThan(after) {
+			continue
+		}
+		newer = append(newer, v)
+	}
+	// go emits versions in ascending order, but picking the greatest version old
+	// enough depends on that order, so don't leave it to another tool's output.
+	sort.Sort(semver.Collection(newer))
+	return newer, nil
+}
+
+// parseTimes maps each version in `go list -m -json` output to its publish
+// time. A version whose time go couldn't determine maps to the zero time.
+func parseTimes(out []byte) (map[string]time.Time, error) {
+	times := map[string]time.Time{}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var listed goListModule
+		if err := dec.Decode(&listed); err != nil {
+			return nil, err
+		}
+		times[listed.Version] = listed.Time
+	}
+	return times, nil
+}

--- a/internal/discover/versions_test.go
+++ b/internal/discover/versions_test.go
@@ -1,0 +1,159 @@
+package discover
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// Captured `go list -m -versions github.com/prometheus/client_golang` output,
+// truncated. Note the prerelease tags: go does list them.
+const versionsOutput = "github.com/prometheus/client_golang v1.23.0-rc.1 v1.23.0 v1.23.1 v1.23.2 v1.24.0-rc.0 v1.24.0 v1.24.1\n"
+
+func TestParseVersions(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		after   string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:  "keeps only versions above after",
+			out:   versionsOutput,
+			after: "v1.23.2",
+			want:  []string{"v1.24.0-rc.0", "v1.24.0", "v1.24.1"},
+		},
+		{
+			name:  "after excludes itself",
+			out:   versionsOutput,
+			after: "v1.24.1",
+			want:  nil,
+		},
+		{
+			name:  "no versions newer is not an error",
+			out:   "example.com/mod v1.0.0\n",
+			after: "v1.0.0",
+			want:  nil,
+		},
+		{
+			name:  "a module with no tagged versions at all is not an error",
+			out:   "example.com/mod\n",
+			after: "v1.0.0",
+			want:  nil,
+		},
+		{
+			name:  "unparseable versions are skipped, not fatal",
+			out:   "example.com/mod v1.1.0 nonsense v1.2.0\n",
+			after: "v1.0.0",
+			want:  []string{"v1.1.0", "v1.2.0"},
+		},
+		{
+			name:  "output is sorted ascending rather than trusted",
+			out:   "example.com/mod v1.10.0 v1.2.0 v1.9.0\n",
+			after: "v1.0.0",
+			want:  []string{"v1.2.0", "v1.9.0", "v1.10.0"},
+		},
+		{
+			name:  "incompatible major versions are kept verbatim",
+			out:   "example.com/mod v1.0.0 v2.0.0+incompatible\n",
+			after: "v1.0.0",
+			want:  []string{"v2.0.0+incompatible"},
+		},
+		{
+			name:    "empty output is an error",
+			out:     "",
+			wantErr: true,
+			after:   "v1.0.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVersions([]byte(tt.out), semver.MustParse(tt.after))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseVersions() = %v, want an error", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseVersions() returned unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseVersions() = %v, want %v", got, tt.want)
+			}
+			for i, want := range tt.want {
+				// Original is what the publish-time queries and the display use.
+				if got[i].Original() != want {
+					t.Errorf("parseVersions()[%d] = %q, want %q", i, got[i].Original(), want)
+				}
+			}
+		})
+	}
+}
+
+// Captured `go list -m -json github.com/fatih/color@v1.16.0
+// github.com/fatih/color@v1.17.0` output, with the fields we ignore trimmed.
+const timesOutput = `{
+	"Path": "github.com/fatih/color",
+	"Version": "v1.16.0",
+	"Time": "2023-11-06T08:25:55Z",
+	"GoVersion": "1.17"
+}
+{
+	"Path": "github.com/fatih/color",
+	"Version": "v1.17.0",
+	"Time": "2024-04-08T12:08:58Z",
+	"GoVersion": "1.17"
+}
+`
+
+func TestParseTimes(t *testing.T) {
+	times, err := parseTimes([]byte(timesOutput))
+	if err != nil {
+		t.Fatalf("parseTimes() returned unexpected error: %v", err)
+	}
+	if len(times) != 2 {
+		t.Fatalf("parseTimes() = %v, want 2 entries", times)
+	}
+	// The keys must be reachable from a parsed version, which is how
+	// versionLookup joins the two go invocations back together.
+	for _, tt := range []struct {
+		version string
+		want    string
+	}{
+		{"v1.16.0", "2023-11-06T08:25:55Z"},
+		{"v1.17.0", "2024-04-08T12:08:58Z"},
+	} {
+		want, err := time.Parse(time.RFC3339, tt.want)
+		if err != nil {
+			t.Fatalf("bad test data %q: %v", tt.want, err)
+		}
+		got, ok := times[semver.MustParse(tt.version).Original()]
+		if !ok {
+			t.Fatalf("parseTimes() has no entry for %s, keys are %v", tt.version, times)
+		}
+		if !got.Equal(want) {
+			t.Errorf("parseTimes()[%s] = %s, want %s", tt.version, got, want)
+		}
+	}
+}
+
+func TestParseTimesMissingTimeDecodesToZero(t *testing.T) {
+	// go omits Time when it can't determine it. The zero value must survive to
+	// the caller, which treats it as an unverifiable age.
+	times, err := parseTimes([]byte(`{"Path":"example.com/mod","Version":"v1.0.0"}`))
+	if err != nil {
+		t.Fatalf("parseTimes() returned unexpected error: %v", err)
+	}
+	if got, ok := times["v1.0.0"]; !ok || !got.IsZero() {
+		t.Errorf("parseTimes()[v1.0.0] = %s, ok = %t, want the zero time", got, ok)
+	}
+}
+
+func TestParseTimesRejectsMalformedJSON(t *testing.T) {
+	if _, err := parseTimes([]byte(`{"Path":`)); err == nil {
+		t.Error("parseTimes() = nil error, want an error for truncated JSON")
+	}
+}

--- a/internal/module/major.go
+++ b/internal/module/major.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/oligot/go-mod-upgrade/internal/api"
@@ -21,6 +22,7 @@ func FindMajorUpgrades(currentPath string, currentVerStr string, items []api.Ver
 		currentMajor  = currentVer.Major()
 		latestByMajor = make(map[uint64]*semver.Version)
 		pathToMajor   = make(map[uint64]string)
+		timeByMajor   = make(map[uint64]time.Time)
 	)
 
 	for _, item := range items {
@@ -52,15 +54,17 @@ func FindMajorUpgrades(currentPath string, currentVerStr string, items []api.Ver
 		if existing, ok := latestByMajor[major]; !ok || v.GreaterThan(existing) {
 			latestByMajor[major] = v
 			pathToMajor[major] = item.ModulePath
+			timeByMajor[major] = item.CommitTime
 		}
 	}
 
 	var upgrades []Module
 	for major, latestVer := range latestByMajor {
 		upgrades = append(upgrades, Module{
-			Name: pathToMajor[major],
-			From: currentVer,
-			To:   latestVer,
+			Name:   pathToMajor[major],
+			From:   currentVer,
+			To:     latestVer,
+			ToTime: timeByMajor[major],
 		})
 	}
 

--- a/internal/module/major_test.go
+++ b/internal/module/major_test.go
@@ -2,13 +2,16 @@ package module
 
 import (
 	"testing"
+	"time"
 
 	"github.com/oligot/go-mod-upgrade/internal/api"
 )
 
+var v3Time = time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+
 func TestFindMajorUpgrades(t *testing.T) {
 	items := []api.VersionItem{
-		{ModulePath: "github.com/foo/bar/v3", Version: "v3.1.0"},
+		{ModulePath: "github.com/foo/bar/v3", Version: "v3.1.0", CommitTime: v3Time},
 		{ModulePath: "github.com/foo/bar/v3", Version: "v3.0.0"},
 		{ModulePath: "github.com/foo/bar/v2", Version: "v2.5.0"},
 		{ModulePath: "github.com/foo/bar/v2", Version: "v2.6.0-rc.1"},
@@ -36,6 +39,11 @@ func TestFindMajorUpgrades(t *testing.T) {
 			foundV3 = true
 			if up.Name != "github.com/foo/bar/v3" || up.To.String() != "3.1.0" {
 				t.Errorf("unexpected v3 upgrade: %+v", up)
+			}
+			// Carried from the API response so cooldown can age the version
+			// without a second lookup.
+			if !up.ToTime.Equal(v3Time) {
+				t.Errorf("v3 toTime = %s, want %s", up.ToTime, v3Time)
 			}
 		}
 	}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
@@ -16,12 +17,22 @@ func padRight(str string, length int) string {
 	return str + strings.Repeat(" ", length-len(str))
 }
 
+// Cooldown records the version that the cooldown window withheld.
+type Cooldown struct {
+	Version *semver.Version
+	Age     time.Duration
+}
+
 type Module struct {
 	Name           string
 	From           *semver.Version
 	To             *semver.Version
 	IsMajorUpgrade bool
 	OldName        string
+	// ToTime is the publish time of the To version.
+	ToTime time.Time
+	// Cooldown is set only when the cooldown window lowered the To version.
+	Cooldown *Cooldown
 }
 
 // MaxWidths returns the width of the longest module name and of the longest
@@ -87,4 +98,31 @@ func (mod *Module) FormatTo() string {
 		fmt.Fprintf(&buf, "%s%s", green("+"), green(to.Metadata()))
 	}
 	return buf.String()
+}
+
+// FormatAge renders a duration coarsely, as minutes, hours or days.
+func FormatAge(d time.Duration) string {
+	// A tag dated in the future, through clock skew or backdating, would
+	// otherwise render as a negative age.
+	if d < 0 {
+		d = 0
+	}
+	switch {
+	case d >= 24*time.Hour:
+		return fmt.Sprintf("%dd", int(d.Hours())/24)
+	case d >= time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+}
+
+// FormatCooldown renders the annotation for a module whose target version was
+// lowered by the cooldown window, or an empty string when it was not.
+func (mod *Module) FormatCooldown() string {
+	if mod.Cooldown == nil {
+		return ""
+	}
+	c := color.New(color.Faint).SprintFunc()
+	return c(fmt.Sprintf(" (%s held, %s old)", mod.Cooldown.Version, FormatAge(mod.Cooldown.Age)))
 }

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -1,7 +1,9 @@
 package module
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/fatih/color"
@@ -66,11 +68,20 @@ func TestMaxWidths(t *testing.T) {
 	}
 }
 
-func TestFormatName(t *testing.T) {
-	// fatih/color drops the escape codes when stdout is not a TTY, which is
-	// exactly the case under `go test`. Without this the assertions below
-	// would compare bare strings and pin nothing.
+// forceColor turns escape codes back on for one test. fatih/color drops them
+// when stdout is not a TTY, which is exactly the case under `go test`, so
+// without this the assertions would compare bare strings and pin nothing. The
+// flag is a package global, hence the restore: leaving it set would change what
+// every later test in the package sees.
+func forceColor(t *testing.T) {
+	t.Helper()
+	previous := color.NoColor
 	color.NoColor = false
+	t.Cleanup(func() { color.NoColor = previous })
+}
+
+func TestFormatName(t *testing.T) {
+	forceColor(t)
 
 	tests := []struct {
 		name string
@@ -96,7 +107,7 @@ func TestFormatName(t *testing.T) {
 }
 
 func TestFormatFrom(t *testing.T) {
-	color.NoColor = false
+	forceColor(t)
 
 	m := mod(t, "a", "1.2.3", "1.2.4")
 	if got, want := m.FormatFrom(8), "\x1b[34m1.2.3   \x1b[0m"; got != want {
@@ -110,7 +121,7 @@ func TestFormatFrom(t *testing.T) {
 }
 
 func TestFormatTo(t *testing.T) {
-	color.NoColor = false
+	forceColor(t)
 
 	tests := []struct {
 		name string
@@ -158,5 +169,62 @@ func TestFormatTo(t *testing.T) {
 				t.Errorf("FormatTo() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatAge(t *testing.T) {
+	tests := []struct {
+		name string
+		age  time.Duration
+		want string
+	}{
+		{"sub-minute", 30 * time.Second, "0m"},
+		{"minutes", 30 * time.Minute, "30m"},
+		{"one hour", time.Hour, "1h"},
+		{"hours truncate", 5*time.Hour + 30*time.Minute, "5h"},
+		{"one day", 24 * time.Hour, "1d"},
+		{"days truncate", 50 * time.Hour, "2d"},
+		{"a week", 7 * 24 * time.Hour, "7d"},
+		{"a future timestamp clamps to zero", -2 * time.Hour, "0m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatAge(tt.age); got != tt.want {
+				t.Errorf("FormatAge(%s) = %q, want %q", tt.age, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatCooldownEmptyWithoutCooldown(t *testing.T) {
+	mod := Module{
+		Name: "example.com/mod",
+		From: semver.MustParse("v1.0.0"),
+		To:   semver.MustParse("v1.1.0"),
+	}
+	if got := mod.FormatCooldown(); got != "" {
+		t.Errorf("FormatCooldown() = %q, want empty string", got)
+	}
+}
+
+func TestFormatCooldownShowsHeldVersionAndAge(t *testing.T) {
+	mod := Module{
+		Name: "example.com/mod",
+		From: semver.MustParse("v1.0.0"),
+		To:   semver.MustParse("v1.1.0"),
+		Cooldown: &Cooldown{
+			Version: semver.MustParse("v1.4.0"),
+			Age:     48 * time.Hour,
+		},
+	}
+	got := mod.FormatCooldown()
+	if !strings.Contains(got, "1.4.0") {
+		t.Errorf("FormatCooldown() = %q, want it to contain the held version 1.4.0", got)
+	}
+	if !strings.Contains(got, "2d") {
+		t.Errorf("FormatCooldown() = %q, want it to contain the age 2d", got)
+	}
+	if !strings.HasPrefix(got, " ") {
+		t.Errorf("FormatCooldown() = %q, want a leading space so it appends cleanly to a row", got)
 	}
 }

--- a/internal/prompt/options.go
+++ b/internal/prompt/options.go
@@ -17,10 +17,11 @@ func buildOptions(modules []module.Module) []huh.Option[module.Module] {
 	options := make([]huh.Option[module.Module], 0, len(modules))
 	for _, mod := range modules {
 		label := fmt.Sprintf(
-			"%s %s -> %s",
+			"%s %s -> %s%s",
 			mod.FormatName(maxName),
 			mod.FormatFrom(maxFrom),
 			mod.FormatTo(),
+			mod.FormatCooldown(),
 		)
 		options = append(options, huh.NewOption(label, mod))
 	}

--- a/main.go
+++ b/main.go
@@ -114,6 +114,12 @@ func main() {
 				Usage:       "Skip the disk cache when checking for major version updates",
 				Destination: &app.NoCache,
 			},
+			&cli.StringFlag{
+				Name:        "cooldown",
+				Aliases:     []string{"c"},
+				Usage:       "Only consider versions published at least this long ago (e.g. 7, 7d, 12h, 30m)",
+				Destination: &app.Cooldown,
+			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			return app.Run()

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,45 @@ Colors in module names help identify the update type:
 * green for a patch update
 * red for a prerelease update
 
+### Cooldown
+
+To avoid adopting a version the moment it is released, use the `--cooldown` flag
+to require that a version has been published for a given period:
+
+```
+go-mod-upgrade --cooldown 7d
+```
+
+Accepted values, following [npm-check-updates](https://github.com/raineorshine/npm-check-updates#cooldown):
+
+| Value | Meaning |
+| --- | --- |
+| `7` | 7 days |
+| `7d` | 7 days |
+| `12h` | 12 hours |
+| `30m` | 30 minutes |
+
+When the latest version falls inside the cooldown window, go-mod-upgrade offers
+the greatest version that is old enough instead, annotating the row with the
+version it withheld:
+
+```
+github.com/foo/bar  1.2.0 -> 1.3.0  (1.4.0 held, 2d old)
+```
+
+If no version satisfies the window, the module is held back entirely and
+reported after discovery:
+
+```
+1 module held back by cooldown (7d):
+  github.com/only/new 1.0.1 (1d old)
+```
+
+Note that Go reports the VCS tag time of a version, not a server-side publish
+time as npm does, so someone in control of a repository could backdate a tag.
+Treat cooldown as a way to let a release settle before adopting it, rather than
+as a hard guarantee against a compromised release.
+
 Additional options can be specified via the CLI global options:
 
 ``` 
@@ -67,6 +106,7 @@ GLOBAL OPTIONS:
    --ignore value, -i value    Ignore modules matching the given regular expression
    --no-major                  Disable checking for major version updates (default: false)
    --no-cache                  Skip the disk cache when checking for major version updates (default: false)
+   --cooldown value, -c value  Only consider versions published at least this long ago (e.g. 7, 7d, 12h, 30m)
    --help, -h                  show help (default: false)
    --version                   print the version (default: false)
 ```


### PR DESCRIPTION
A brand-new release is the riskiest moment to upgrade: a compromised release or a regression is usually caught within days. Waiting a while before adopting a version costs little and avoids most of that exposure. This ports the cooldown feature of npm-check-updates, accepting the same syntax (a bare integer means days; d, h and m suffixes).

When the latest version falls inside the window we offer the greatest version that is old enough rather than skipping the module outright, matching ncu's default --target latest behavior. Only when no version above the current one qualifies is the module held back entirely, and those are reported in a summary so nothing disappears silently. Age checks fail closed: a version whose publish time cannot be determined is withheld rather than offered, and a lookup failure holds back one module without aborting the run.

The filter lives in a new internal/cooldown package with the clock and the version lookup injected, so every branch is unit-testable without executing go or reaching the network. These are the first tests in the repository.

Two supporting changes were required:

Module discovery moves from a quoted go list text template plus a regex to go list -m -u -json. That is what makes each candidate version's publish time available, and it retires a fragile parsing path.

update() now runs `go get <module>@<version>` instead of `go get <module>`. The bare form means @upgrade, which resolves to the latest release — it only worked before because the target was always the latest, an invariant cooldown is the first thing to break. Without this the tool would display and consent to a lowered target while installing the very version cooldown withheld. As a side effect the ordinary upgrade path now installs exactly the version that was shown, closing a window between discovery and update.

Note that Go reports the VCS tag time of a version, not a server-side publish time as npm does, so someone in control of a repository could backdate a tag. Cooldown is a way to let a release settle before adopting it, not a hard guarantee against a compromised release. The readme says so.