### PR TITLE
refactor: extract shared seams before landing three feature branches

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,33 +10,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/AlecAivazis/survey/v2"
-	term "github.com/AlecAivazis/survey/v2/terminal"
-	"github.com/Masterminds/semver/v3"
 	"github.com/apex/log"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
 	"golang.org/x/mod/modfile"
 
+	"github.com/oligot/go-mod-upgrade/internal/discover"
 	"github.com/oligot/go-mod-upgrade/internal/module"
+	"github.com/oligot/go-mod-upgrade/internal/prompt"
 )
-
-func max(x, y int) int {
-	if x > y {
-		return x
-	}
-	return y
-}
-
-// MultiSelect that doesn't show the answer
-// It just reset the prompt and the answers are shown afterwards
-type MultiSelect struct {
-	survey.MultiSelect
-}
-
-func (m MultiSelect) Cleanup(config *survey.PromptConfig, val interface{}) error {
-	return m.Render("", nil)
-}
 
 type AppEnv struct {
 	Verbose  bool
@@ -50,295 +33,133 @@ func (app *AppEnv) Run() error {
 	if app.Verbose {
 		log.SetLevel(log.DebugLevel)
 	}
-	var paths []string
+	ignore, err := discover.CompileIgnore(app.Ignore)
+	if err != nil {
+		return err
+	}
+	// Deliberately not routed through discover.Exec: that sets GOWORK=off,
+	// which would make this always report "off" and break workspace detection.
 	gw, err := exec.Command("go", "env", "GOWORK").Output()
 	if err != nil {
 		return err
 	}
 	gowork := strings.TrimSpace(string(gw))
-	if gowork == "" || gowork == "off" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		paths = append(paths, cwd)
-	} else {
-		log.WithField("gowork", gowork).Info("Workspace mode")
-		content, err := os.ReadFile(gowork)
-		if err != nil {
-			return err
-		}
-		work, err := modfile.ParseWork("go.work", content, nil)
-		if err != nil {
-			return err
-		}
-		for _, use := range work.Use {
-			if use != nil {
-				paths = append(paths, use.Path)
-			}
-		}
+	paths, err := workspacePaths(gowork)
+	if err != nil {
+		return err
 	}
 
 	for _, path := range paths {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
 		dir := path
 		if !filepath.IsAbs(path) {
 			dir = filepath.Join(filepath.Dir(gowork), path)
 		}
 		log.WithField("dir", dir).Info("Using directory")
-		if err := os.Chdir(dir); err != nil {
-			return err
-		}
-		modules, err := discoverModules(app.Ignore)
-		if err != nil {
-			return err
-		}
-		supported, err := toolsSupported()
-		if err != nil {
-			return err
-		}
-		log.WithFields(log.Fields{
-			"supported": supported,
-		}).Debug("Tool support")
-		if supported {
-			toolModules, err := discoverTools(app.Ignore)
-			if err != nil {
-				return err
+		if err := app.runDir(dir, ignore); err != nil {
+			// Ctrl+C means stop the whole walk, not just this module: handle
+			// the abort here rather than inside runDir.
+			if errors.Is(err, prompt.ErrAborted) {
+				log.Info("Bye")
+				return nil
 			}
-			modules = append(modules, toolModules...)
-		}
-		if len(modules) > 0 {
-			if app.List {
-				listModules(modules)
-			} else if app.Force {
-				log.Debug("Update all modules in non-interactive mode...")
-				update(modules, app.Hook)
-			} else {
-				modules = choose(modules, app.PageSize)
-				update(modules, app.Hook)
-			}
-		} else {
-			fmt.Println("All modules are up to date")
-		}
-		if err := os.Chdir(cwd); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func discoverModules(ignoreNames []string) ([]module.Module, error) {
-	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-	if err := s.Color("yellow"); err != nil {
+// workspacePaths returns the module directories to walk: the current directory
+// outside workspace mode, every `use` entry of the go.work file inside it.
+func workspacePaths(gowork string) ([]string, error) {
+	if gowork == "" || gowork == "off" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		return []string{cwd}, nil
+	}
+	log.WithField("gowork", gowork).Info("Workspace mode")
+	content, err := os.ReadFile(gowork)
+	if err != nil {
 		return nil, err
 	}
-	s.Suffix = " Discovering modules..."
-	s.Start()
-
-	args := []string{
-		"list",
-		"-u",
-		"-mod=readonly",
-		"-f",
-		"'{{if (and (not (or .Main .Indirect)) .Update)}}{{.Path}}: {{.Version}} -> {{.Update.Version}}{{end}}'",
-		"-m",
-		"all",
-	}
-
-	cmd := exec.Command("go", args...)
-	// Disable Go workspace mode, otherwise this can cause trouble
-	// See issue https://github.com/oligot/go-mod-upgrade/issues/35
-	cmd.Env = append(os.Environ(), "GOWORK=off")
-	list, err := cmd.Output()
-	s.Stop()
-
-	// Clear line
-	fmt.Printf("\r%s\r", strings.Repeat(" ", len(s.Suffix)+1))
-
+	work, err := modfile.ParseWork("go.work", content, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error running go command to discover modules: %w", err)
-	}
-
-	split := strings.Split(string(list), "\n")
-	modules := []module.Module{}
-	re := regexp.MustCompile(`'(.+): (.+) -> (.+)'`)
-	for _, x := range split {
-		if x != "''" && x != "" {
-			matched := re.FindStringSubmatch(x)
-			if len(matched) < 4 {
-				return nil, fmt.Errorf("couldn't parse module %s", x)
-			}
-			name, from, to := matched[1], matched[2], matched[3]
-			log.WithFields(log.Fields{
-				"name": name,
-				"from": from,
-				"to":   to,
-			}).Debug("Found module")
-			if shouldIgnore(name, from, to, ignoreNames) {
-				continue
-			}
-			fromversion, err := semver.NewVersion(from)
-			if err != nil {
-				return nil, err
-			}
-			toversion, err := semver.NewVersion(to)
-			if err != nil {
-				return nil, err
-			}
-			d := module.Module{
-				Name: name,
-				From: fromversion,
-				To:   toversion,
-			}
-			modules = append(modules, d)
-		}
-	}
-	return modules, nil
-}
-
-func discoverTools(ignoreNames []string) ([]module.Module, error) {
-
-	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
-	if err := s.Color("yellow"); err != nil {
 		return nil, err
 	}
-	s.Suffix = " Discovering tool modules..."
-	s.Start()
-
-	toolsArgs := []string{
-		"list",
-		"-f",
-		"{{if .Module}}{{.Module.Path}} {{.Module.Version}}{{end}}",
-		"tool",
-	}
-	cmd := exec.Command("go", toolsArgs...)
-	cmd.Env = append(os.Environ(), "GOWORK=off")
-	toolsOutput, err := cmd.Output()
-
-	s.Stop()
-	fmt.Printf("\r%s\r", strings.Repeat(" ", len(s.Suffix)+1))
-
-	if err != nil {
-		if strings.Contains(err.Error(), "matched no packages") {
-			return []module.Module{}, nil
-		}
-		log.WithFields(log.Fields{
-			"error": err,
-			"args":  cmd.Args,
-		}).Error("error listing tools")
-		return nil, fmt.Errorf("error listing tools: %w", err)
-	}
-
-	var modules []module.Module
-	tools := strings.Split(strings.TrimSpace(string(toolsOutput)), "\n")
-	for _, tool := range tools {
-		if tool == "" {
-			continue
-		}
-
-		parts := strings.Fields(tool)
-		if len(parts) == 1 {
-			continue // local tool
-		}
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid tool format: %s", tool)
-		}
-		toolPath, currentVersion := parts[0], parts[1]
-
-		// Check for updates
-		updateArgs := []string{
-			"list",
-			"-m",
-			"-f",
-			"{{if .Update}}{{.Update.Version}}{{end}}",
-			"-u",
-			toolPath,
-		}
-		updateCmd := exec.Command("go", updateArgs...)
-		updateCmd.Env = append(os.Environ(), "GOWORK=off")
-		if updateOutput, err := updateCmd.Output(); err == nil {
-			newVersion := strings.TrimSpace(string(updateOutput))
-			if newVersion != "" && newVersion != currentVersion {
-				fromVersion, err := semver.NewVersion(currentVersion)
-				if err != nil {
-					return nil, fmt.Errorf("invalid tool version: %s -> %s: %w", toolPath, currentVersion, err)
-				}
-				toVersion, err := semver.NewVersion(newVersion)
-				if err != nil {
-					return nil, fmt.Errorf("invalid tool update version: %s -> %s: %w", toolPath, newVersion, err)
-				}
-				log.WithFields(log.Fields{
-					"tool": toolPath,
-					"from": currentVersion,
-					"to":   newVersion,
-				}).Debug("Found tool module update available")
-				if shouldIgnore(toolPath, currentVersion, newVersion, ignoreNames) {
-					continue
-				}
-				modules = append(modules, module.Module{
-					Name: toolPath,
-					From: fromVersion,
-					To:   toVersion,
-				})
-			}
+	var paths []string
+	for _, use := range work.Use {
+		if use != nil {
+			paths = append(paths, use.Path)
 		}
 	}
-
-	return modules, nil
+	return paths, nil
 }
 
-func toolsSupported() (bool, error) {
-	gv, err := exec.Command("go", "version").Output()
+// runDir discovers and updates the modules of one module directory.
+func (app *AppEnv) runDir(dir string, ignore []*regexp.Regexp) error {
+	d := discover.Discoverer{Run: discover.Exec, Dir: dir, Ignore: ignore}
+	modules, err := withSpinner(" Discovering modules...", d.Modules)
 	if err != nil {
-		return false, err
+		return err
 	}
-
-	version := strings.TrimSpace(string(gv))
-	re := regexp.MustCompile(`go version go([\d\.]+)(rc.+)?`)
-	matched := re.FindStringSubmatch(version)
-	if len(matched) < 2 {
-		return false, fmt.Errorf("couldn't parse go version %s", version)
-	}
-
-	goversion, err := semver.NewVersion(matched[1])
+	// Asked per directory: workspace members can pin different toolchains.
+	supported, err := d.ToolsSupported()
 	if err != nil {
-		return false, err
+		return err
 	}
 	log.WithFields(log.Fields{
-		"major": goversion.Major(),
-		"minor": goversion.Minor(),
-	}).Debug("Go version")
-	if goversion.Major() >= 1 && goversion.Minor() >= 24 {
-		return true, nil
+		"dir":       dir,
+		"supported": supported,
+	}).Debug("Tool support")
+	if supported {
+		toolModules, err := withSpinner(" Discovering tool modules...", d.Tools)
+		if err != nil {
+			return err
+		}
+		modules = append(modules, toolModules...)
 	}
-	return false, nil
+
+	if len(modules) == 0 {
+		fmt.Println("All modules are up to date")
+		return nil
+	}
+	if app.List {
+		listModules(modules)
+		return nil
+	}
+	if app.Force {
+		log.Debug("Update all modules in non-interactive mode...")
+		return update(dir, modules, app.Hook)
+	}
+	selected, err := prompt.Choose(modules, app.PageSize)
+	if err != nil {
+		return err
+	}
+	return update(dir, selected, app.Hook)
 }
 
-func shouldIgnore(name, from, to string, ignoreNames []string) bool {
-	for _, ig := range ignoreNames {
-		if strings.Contains(name, ig) {
-			c := color.New(color.FgYellow).SprintFunc()
-			log.WithFields(log.Fields{
-				"name": name,
-				"from": from,
-				"to":   to,
-			}).Debug(c("Ignore module"))
-			return true
-		}
+// withSpinner runs fn behind the discovery spinner and clears the line
+// afterwards, the way the discovery functions used to do inline.
+func withSpinner[T any](suffix string, fn func() (T, error)) (T, error) {
+	var zero T
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	if err := s.Color("yellow"); err != nil {
+		return zero, err
 	}
-	return false
+	s.Suffix = suffix
+	s.Start()
+
+	result, err := fn()
+
+	s.Stop()
+	// Clear line
+	fmt.Printf("\r%s\r", strings.Repeat(" ", len(s.Suffix)+1))
+	return result, err
 }
 
 func listModules(modules []module.Module) {
-	maxName := 0
-	maxFrom := 0
-	for _, x := range modules {
-		maxName = max(maxName, len(x.Name))
-		maxFrom = max(maxFrom, len(x.From.String()))
-	}
+	maxName, maxFrom := module.MaxWidths(modules)
 	for _, x := range modules {
 		from := x.FormatFrom(maxFrom)
 		_, err := fmt.Fprintf(color.Output, "%s %s -> %s\n", x.FormatName(maxName), from, x.FormatTo())
@@ -351,43 +172,7 @@ func listModules(modules []module.Module) {
 	}
 }
 
-func choose(modules []module.Module, pageSize int) []module.Module {
-	maxName := 0
-	maxFrom := 0
-	for _, x := range modules {
-		maxName = max(maxName, len(x.Name))
-		maxFrom = max(maxFrom, len(x.From.String()))
-	}
-	options := []string{}
-	for _, x := range modules {
-		from := x.FormatFrom(maxFrom)
-		option := fmt.Sprintf("%s %s -> %s", x.FormatName(maxName), from, x.FormatTo())
-		options = append(options, option)
-	}
-	prompt := &MultiSelect{
-		survey.MultiSelect{
-			Message:  "Choose which modules to update",
-			Options:  options,
-			PageSize: pageSize,
-		},
-	}
-	choice := []int{}
-	err := survey.AskOne(prompt, &choice)
-	if err == term.InterruptErr {
-		log.Info("Bye")
-		os.Exit(0)
-	} else if err != nil {
-		log.WithError(err).Error("Choose failed")
-		os.Exit(1)
-	}
-	updates := []module.Module{}
-	for _, x := range choice {
-		updates = append(updates, modules[x])
-	}
-	return updates
-}
-
-func update(modules []module.Module, hook string) {
+func update(dir string, modules []module.Module, hook string) error {
 	for _, x := range modules {
 		_, err := fmt.Fprintf(color.Output, "Updating %s to version %s...\n", x.FormatName(len(x.Name)), x.FormatTo())
 		if err != nil {
@@ -396,8 +181,13 @@ func update(modules []module.Module, hook string) {
 				"name":  x.Name,
 			}).Error("Error while updating module")
 		}
-		out, err := exec.Command("go", "get", "-d", x.Name).CombinedOutput()
+		// Deliberately not routed through discover.Exec: `go get` runs without
+		// GOWORK=off today, and setting it would be a silent behaviour change.
+		get := exec.Command("go", "get", x.Name)
+		get.Dir = dir
+		out, err := get.CombinedOutput()
 		if err != nil {
+			// Logged, not fatal: the remaining modules still get their turn.
 			log.WithFields(log.Fields{
 				"error": err,
 				"name":  x.Name,
@@ -405,21 +195,22 @@ func update(modules []module.Module, hook string) {
 			}).Error("Error while updating module")
 		}
 		if hook != "" {
-			out, err := exec.Command(
+			// cmd.Dir reproduces both halves of the old os.Chdir behaviour: the
+			// child's cwd is the module directory, and a relative hook path
+			// resolves against that directory.
+			cmd := exec.Command(
 				hook,
 				x.Name,
 				x.From.String(),
 				x.To.String(),
-			).CombinedOutput()
+			)
+			cmd.Dir = dir
+			out, err := cmd.CombinedOutput()
 			if err != nil {
-				log.WithFields(log.Fields{
-					"error": err,
-					"hook":  hook,
-					"out":   string(out),
-				}).Error("Error while executing hook")
-				os.Exit(1)
+				return fmt.Errorf("hook %s: %w: %s", hook, err, strings.TrimSpace(string(out)))
 			}
 			log.Info(string(out))
 		}
 	}
+	return nil
 }

--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -1,0 +1,118 @@
+// Package discover finds outdated modules and tool modules with `go list`.
+package discover
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/apex/log"
+
+	"github.com/oligot/go-mod-upgrade/internal/module"
+)
+
+// Runner runs the go command in dir and returns its standard output. Every
+// implementation sets GOWORK=off; see [Exec].
+type Runner func(dir string, args ...string) ([]byte, error)
+
+// Exec is the one real Runner. Tests pass a closure instead.
+func Exec(dir string, args ...string) ([]byte, error) {
+	cmd := exec.Command("go", args...)
+	cmd.Dir = dir
+	// Disable Go workspace mode, otherwise this can cause trouble
+	// See issue https://github.com/oligot/go-mod-upgrade/issues/35
+	cmd.Env = append(os.Environ(), "GOWORK=off")
+	return cmd.Output()
+}
+
+// The `go list -f` templates. They live here as constants so the tests can
+// assert which arguments get built without repeating them.
+const (
+	toolsFormat      = "{{if .Module}}{{.Module.Path}} {{.Module.Version}}{{end}}"
+	toolUpdateFormat = "{{if .Update}}{{.Update.Version}}{{end}}"
+)
+
+// Discoverer lists the outdated modules of one module directory.
+type Discoverer struct {
+	Run    Runner
+	Dir    string
+	Ignore []*regexp.Regexp
+}
+
+// Modules returns the direct dependencies that have an update available.
+func (d Discoverer) Modules() ([]module.Module, error) {
+	list, err := d.Run(d.Dir, "list", "-m", "-u", "-mod=readonly", "-json", "all")
+	if err != nil {
+		return nil, fmt.Errorf("error running go command to discover modules: %w", err)
+	}
+	return parseModules(list, d.Ignore)
+}
+
+// Tools returns the module-backed tools that have an update available.
+func (d Discoverer) Tools() ([]module.Module, error) {
+	args := []string{"list", "-f", toolsFormat, "tool"}
+	out, err := d.Run(d.Dir, args...)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+			"args":  append([]string{"go"}, args...),
+		}).Error("error listing tools")
+		return nil, fmt.Errorf("error listing tools: %w", err)
+	}
+
+	tools, err := parseTools(out)
+	if err != nil {
+		return nil, err
+	}
+
+	var modules []module.Module
+	for _, t := range tools {
+		// A tool whose update check fails is skipped, not fatal.
+		updateOutput, err := d.Run(d.Dir, "list", "-m", "-f", toolUpdateFormat, "-u", t.path)
+		if err != nil {
+			continue
+		}
+		newVersion := strings.TrimSpace(string(updateOutput))
+		if newVersion == "" || newVersion == t.version {
+			continue
+		}
+		fromVersion, err := semver.NewVersion(t.version)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tool version: %s -> %s: %w", t.path, t.version, err)
+		}
+		toVersion, err := semver.NewVersion(newVersion)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tool update version: %s -> %s: %w", t.path, newVersion, err)
+		}
+		log.WithFields(log.Fields{
+			"tool": t.path,
+			"from": t.version,
+			"to":   newVersion,
+		}).Debug("Found tool module update available")
+		if shouldIgnore(t.path, t.version, newVersion, d.Ignore) {
+			continue
+		}
+		modules = append(modules, module.Module{
+			Name: t.path,
+			From: fromVersion,
+			To:   toVersion,
+		})
+	}
+
+	return modules, nil
+}
+
+// ToolsSupported reports whether d.Dir's toolchain supports tool modules.
+// `go version` selects its toolchain from the go.mod of the directory it runs
+// in, so this has to be asked per module directory: in workspace mode members
+// can pin toolchains straddling the 1.24 tool-module gate.
+func (d Discoverer) ToolsSupported() (bool, error) {
+	gv, err := d.Run(d.Dir, "version")
+	if err != nil {
+		return false, err
+	}
+	return parseGoVersion(gv)
+}

--- a/internal/discover/discover_test.go
+++ b/internal/discover/discover_test.go
@@ -1,0 +1,145 @@
+package discover
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+// recorder is a Runner that records its calls and replays canned output.
+type recorder struct {
+	calls   [][]string // each call as dir followed by args
+	outputs [][]byte
+	errs    []error
+	n       int
+}
+
+func (r *recorder) run(dir string, args ...string) ([]byte, error) {
+	r.calls = append(r.calls, append([]string{dir}, args...))
+	i := r.n
+	r.n++
+	var out []byte
+	if i < len(r.outputs) {
+		out = r.outputs[i]
+	}
+	var err error
+	if i < len(r.errs) {
+		err = r.errs[i]
+	}
+	return out, err
+}
+
+func TestModulesBuildsArgs(t *testing.T) {
+	r := &recorder{outputs: [][]byte{[]byte(`{"Path":"example.com/a","Version":"v1.0.0","Update":{"Version":"v1.1.0"}}`)}}
+	d := Discoverer{Run: r.run, Dir: "/work/member"}
+
+	modules, err := d.Modules()
+	if err != nil {
+		t.Fatalf("Modules: %v", err)
+	}
+	if len(modules) != 1 || modules[0].Name != "example.com/a" {
+		t.Fatalf("modules = %+v, want one example.com/a", modules)
+	}
+
+	want := []string{"/work/member", "list", "-m", "-u", "-mod=readonly", "-json", "all"}
+	if len(r.calls) != 1 || !slices.Equal(r.calls[0], want) {
+		t.Errorf("calls = %v, want exactly one %v", r.calls, want)
+	}
+}
+
+func TestModulesWrapsRunError(t *testing.T) {
+	boom := errors.New("boom")
+	d := Discoverer{Run: (&recorder{errs: []error{boom}}).run}
+	_, err := d.Modules()
+	if !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want it to wrap %v", err, boom)
+	}
+}
+
+func TestToolsBuildsArgsAndChecksEachTool(t *testing.T) {
+	r := &recorder{outputs: [][]byte{
+		[]byte("example.com/cmd/tool v1.2.0\nlocalonly\n"),
+		[]byte("v1.3.0\n"),
+	}}
+	d := Discoverer{Run: r.run, Dir: "/work/member"}
+
+	modules, err := d.Tools()
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if len(modules) != 1 {
+		t.Fatalf("modules = %+v, want one", modules)
+	}
+	if got := modules[0].To.String(); got != "1.3.0" {
+		t.Errorf("to = %q, want 1.3.0", got)
+	}
+
+	// The local tool gets no update check, so there are exactly two calls.
+	wantList := []string{"/work/member", "list", "-f", toolsFormat, "tool"}
+	wantCheck := []string{"/work/member", "list", "-m", "-f", toolUpdateFormat, "-u", "example.com/cmd/tool"}
+	if len(r.calls) != 2 {
+		t.Fatalf("calls = %v, want 2", r.calls)
+	}
+	if !slices.Equal(r.calls[0], wantList) {
+		t.Errorf("first call = %v, want %v", r.calls[0], wantList)
+	}
+	if !slices.Equal(r.calls[1], wantCheck) {
+		t.Errorf("second call = %v, want %v", r.calls[1], wantCheck)
+	}
+}
+
+func TestToolsPropagatesRunErrorEvenWhenItMentionsMatchedNoPackages(t *testing.T) {
+	// The deleted guard swallowed any error whose message contained
+	// "matched no packages". It never fired — that warning goes to stderr and
+	// exec.ExitError.Error() is only "exit status 1" — but if it ever had, it
+	// would have hidden a real failure. Errors now always propagate.
+	boom := errors.New("exit status 1: matched no packages")
+	d := Discoverer{Run: (&recorder{errs: []error{boom}}).run}
+	if _, err := d.Tools(); !errors.Is(err, boom) {
+		t.Fatalf("error = %v, want it to wrap %v", err, boom)
+	}
+}
+
+func TestToolsWithNoToolsIsEmptyAndNoError(t *testing.T) {
+	// `go list ... tool` exits 0 with its warning on stderr, so stdout is
+	// empty and no error is returned.
+	d := Discoverer{Run: (&recorder{outputs: [][]byte{{}}}).run}
+	modules, err := d.Tools()
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if len(modules) != 0 {
+		t.Errorf("modules = %+v, want none", modules)
+	}
+}
+
+func TestToolsSkipsAToolWhoseCheckFails(t *testing.T) {
+	r := &recorder{
+		outputs: [][]byte{[]byte("example.com/cmd/tool v1.2.0\n"), nil},
+		errs:    []error{nil, errors.New("network down")},
+	}
+	d := Discoverer{Run: r.run}
+	modules, err := d.Tools()
+	if err != nil {
+		t.Fatalf("Tools: %v", err)
+	}
+	if len(modules) != 0 {
+		t.Errorf("modules = %+v, want none: a failed update check is skipped, not fatal", modules)
+	}
+}
+
+func TestToolsSupportedRunsInTheModuleDir(t *testing.T) {
+	r := &recorder{outputs: [][]byte{[]byte("go version go1.26.3 darwin/arm64\n")}}
+	d := Discoverer{Run: r.run, Dir: "/ws/member"}
+	supported, err := d.ToolsSupported()
+	if err != nil {
+		t.Fatalf("ToolsSupported: %v", err)
+	}
+	if !supported {
+		t.Error("supported = false, want true for go1.26.3")
+	}
+	want := []string{"/ws/member", "version"}
+	if len(r.calls) != 1 || !slices.Equal(r.calls[0], want) {
+		t.Errorf("calls = %v, want exactly one %v", r.calls, want)
+	}
+}

--- a/internal/discover/parse.go
+++ b/internal/discover/parse.go
@@ -1,0 +1,142 @@
+package discover
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/apex/log"
+	"github.com/fatih/color"
+
+	"github.com/oligot/go-mod-upgrade/internal/module"
+)
+
+// tool is a module-backed tool named by `go list ... tool`.
+type tool struct {
+	path    string
+	version string
+}
+
+// goListModule is the subset of `go list -m -json` output that we use.
+type goListModule struct {
+	Path     string
+	Version  string
+	Main     bool
+	Indirect bool
+	Update   *goListModule
+}
+
+// parseModules turns `go list -m -json` output into modules, dropping ignored
+// ones. The output is a stream of concatenated objects, not an array.
+func parseModules(out []byte, ignore []*regexp.Regexp) ([]module.Module, error) {
+	modules := []module.Module{}
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var listed goListModule
+		if err := dec.Decode(&listed); err != nil {
+			return nil, fmt.Errorf("error parsing go list output: %w", err)
+		}
+		if listed.Main || listed.Indirect || listed.Update == nil {
+			continue
+		}
+		name, from, to := listed.Path, listed.Version, listed.Update.Version
+		log.WithFields(log.Fields{
+			"name": name,
+			"from": from,
+			"to":   to,
+		}).Debug("Found module")
+		if shouldIgnore(name, from, to, ignore) {
+			continue
+		}
+		fromversion, err := semver.NewVersion(from)
+		if err != nil {
+			return nil, err
+		}
+		toversion, err := semver.NewVersion(to)
+		if err != nil {
+			return nil, err
+		}
+		modules = append(modules, module.Module{
+			Name: name,
+			From: fromversion,
+			To:   toversion,
+		})
+	}
+	return modules, nil
+}
+
+// parseTools turns `go list -f ... tool` output into tool paths and versions.
+// Tools with no module — local ones — are skipped.
+func parseTools(out []byte) ([]tool, error) {
+	var tools []tool
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) == 1 {
+			continue // local tool
+		}
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid tool format: %s", line)
+		}
+		tools = append(tools, tool{path: parts[0], version: parts[1]})
+	}
+	return tools, nil
+}
+
+// parseGoVersion reports whether `go version` output names a toolchain that
+// supports tool modules.
+func parseGoVersion(out []byte) (bool, error) {
+	version := strings.TrimSpace(string(out))
+	re := regexp.MustCompile(`go version go([\d\.]+)(rc.+)?`)
+	matched := re.FindStringSubmatch(version)
+	if len(matched) < 2 {
+		return false, fmt.Errorf("couldn't parse go version %s", version)
+	}
+
+	goversion, err := semver.NewVersion(matched[1])
+	if err != nil {
+		return false, err
+	}
+	log.WithFields(log.Fields{
+		"major": goversion.Major(),
+		"minor": goversion.Minor(),
+	}).Debug("Go version")
+	if goversion.Major() >= 1 && goversion.Minor() >= 24 {
+		return true, nil
+	}
+	return false, nil
+}
+
+// CompileIgnore compiles the --ignore patterns, rejecting invalid ones up
+// front rather than per module.
+func CompileIgnore(patterns []string) ([]*regexp.Regexp, error) {
+	res := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --ignore pattern %q: %w", p, err)
+		}
+		res = append(res, re)
+	}
+	return res, nil
+}
+
+func shouldIgnore(name, from, to string, ignore []*regexp.Regexp) bool {
+	for _, re := range ignore {
+		if re.MatchString(name) {
+			c := color.New(color.FgYellow).SprintFunc()
+			log.WithFields(log.Fields{
+				"name": name,
+				"from": from,
+				"to":   to,
+			}).Debug(c("Ignore module"))
+			return true
+		}
+	}
+	return false
+}

--- a/internal/discover/parse_test.go
+++ b/internal/discover/parse_test.go
@@ -1,0 +1,223 @@
+package discover
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// readFixture returns captured `go list` output.
+func readFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	out, err := os.ReadFile("testdata/" + name)
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	return out
+}
+
+func TestParseModulesFixture(t *testing.T) {
+	modules, err := parseModules(readFixture(t, "list-modules.json"), nil)
+	if err != nil {
+		t.Fatalf("parseModules: %v", err)
+	}
+	// The main module, the indirect one, and the one with no Update are skipped.
+	if len(modules) != 3 {
+		t.Fatalf("got %d modules, want 3: %+v", len(modules), modules)
+	}
+	if modules[0].Name != "github.com/AlecAivazis/survey/v2" {
+		t.Errorf("first module = %q, want github.com/AlecAivazis/survey/v2", modules[0].Name)
+	}
+	if got := modules[0].From.String(); got != "2.3.7" {
+		t.Errorf("first from = %q, want 2.3.7", got)
+	}
+	if got := modules[0].To.String(); got != "2.3.8" {
+		t.Errorf("first to = %q, want 2.3.8", got)
+	}
+	for _, m := range modules {
+		if m.Name == "github.com/mattn/go-isatty" {
+			t.Error("an indirect module must not be offered for update")
+		}
+		if m.Name == "golang.org/x/mod" {
+			t.Error("a module with no available update must not be offered")
+		}
+	}
+}
+
+func TestParseModulesIgnore(t *testing.T) {
+	ignore, err := CompileIgnore([]string{`^github\.com/apex/`})
+	if err != nil {
+		t.Fatalf("CompileIgnore: %v", err)
+	}
+	modules, err := parseModules(readFixture(t, "list-modules.json"), ignore)
+	if err != nil {
+		t.Fatalf("parseModules: %v", err)
+	}
+	if len(modules) != 2 {
+		t.Fatalf("got %d modules, want 2: %+v", len(modules), modules)
+	}
+	for _, m := range modules {
+		if strings.Contains(m.Name, "apex") {
+			t.Errorf("module %q should have been ignored", m.Name)
+		}
+	}
+}
+
+func TestParseModulesErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		wantErr string
+	}{
+		{
+			name:    "not JSON at all",
+			out:     "garbage\n",
+			wantErr: "error parsing go list output",
+		},
+		{
+			name:    "a version semver rejects",
+			out:     `{"Path":"example.com/a","Version":"nope","Update":{"Version":"v1.3.0"}}`,
+			wantErr: "invalid semantic version",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseModules([]byte(tt.out), nil)
+			if err == nil {
+				t.Fatalf("parseModules(%q) returned no error, want %q", tt.out, tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseTools(t *testing.T) {
+	tools, err := parseTools(readFixture(t, "list-tools.txt"))
+	if err != nil {
+		t.Fatalf("parseTools: %v", err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("got %d tools, want 2: %+v", len(tools), tools)
+	}
+	if tools[0] != (tool{path: "example.com/cmd/tool", version: "v1.2.0"}) {
+		t.Errorf("first tool = %+v", tools[0])
+	}
+	// The one-field line is a local tool and is skipped silently.
+	if tools[1] != (tool{path: "example.com/other/tool", version: "v0.4.1"}) {
+		t.Errorf("second tool = %+v", tools[1])
+	}
+}
+
+func TestParseToolsEmpty(t *testing.T) {
+	// With no tools, `go list ... tool` exits 0 and puts its warning on
+	// stderr, so stdout is empty and no error is returned. Empty result, no
+	// error, and no special-case branch needed to get there.
+	tools, err := parseTools([]byte(""))
+	if err != nil {
+		t.Fatalf("parseTools(empty): %v", err)
+	}
+	if len(tools) != 0 {
+		t.Errorf("got %d tools, want none: %+v", len(tools), tools)
+	}
+}
+
+func TestParseToolsThreeFields(t *testing.T) {
+	_, err := parseTools([]byte("a b c\n"))
+	if err == nil {
+		t.Fatal("parseTools(\"a b c\") returned no error, want invalid tool format")
+	}
+	if want := "invalid tool format: a b c"; err.Error() != want {
+		t.Errorf("error = %q, want %q", err, want)
+	}
+}
+
+func TestParseGoVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		out     string
+		want    bool
+		wantErr string
+	}{
+		{name: "current toolchain", out: "go version go1.26.3 darwin/arm64\n", want: true},
+		{name: "release candidate", out: "go version go1.24rc1 linux/amd64\n", want: true},
+		{
+			// Pinned as-is despite being wrong: the gate is
+			// `Major() >= 1 && Minor() >= 24`, so a hypothetical go2.0 —
+			// minor 0 — reports tool modules as unsupported.
+			name: "a hypothetical go2.0 reports unsupported",
+			out:  "go version go2.0 linux/amd64\n",
+			want: false,
+		},
+		{
+			name:    "unparseable",
+			out:     "garbage\n",
+			wantErr: "couldn't parse go version garbage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseGoVersion([]byte(tt.out))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseGoVersion: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("parseGoVersion(%q) = %v, want %v", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompileIgnore(t *testing.T) {
+	res, err := CompileIgnore([]string{`^github\.com/apex/`, `log$`})
+	if err != nil {
+		t.Fatalf("CompileIgnore: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("got %d patterns, want 2", len(res))
+	}
+	if _, err := CompileIgnore([]string{"("}); err == nil {
+		t.Fatal("CompileIgnore(\"(\") returned no error, want an invalid-pattern error")
+	} else if !strings.Contains(err.Error(), `invalid --ignore pattern "("`) {
+		t.Errorf("error = %q, want it to name the bad pattern", err)
+	}
+	if res, err := CompileIgnore(nil); err != nil || len(res) != 0 {
+		t.Errorf("CompileIgnore(nil) = %v, %v, want empty and no error", res, err)
+	}
+}
+
+func TestShouldIgnore(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{name: "an unanchored pattern still matches anywhere", pattern: "apex", want: true},
+		{name: "the full path", pattern: `^github\.com/apex/log$`, want: true},
+		{name: "an anchor that does not match", pattern: "^apex", want: false},
+		{name: "a metacharacter is now a metacharacter", pattern: `apex/.*/log`, want: false},
+		{name: "a character class", pattern: `github\.com/[a-z]+/log`, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ignore, err := CompileIgnore([]string{tt.pattern})
+			if err != nil {
+				t.Fatalf("CompileIgnore(%q): %v", tt.pattern, err)
+			}
+			got := shouldIgnore("github.com/apex/log", "1.9.0", "1.9.1", ignore)
+			if got != tt.want {
+				t.Errorf("shouldIgnore with %q = %v, want %v", tt.pattern, got, tt.want)
+			}
+		})
+	}
+	if shouldIgnore("github.com/apex/log", "1.9.0", "1.9.1", nil) {
+		t.Error("no patterns should ignore nothing")
+	}
+}

--- a/internal/discover/testdata/list-modules.json
+++ b/internal/discover/testdata/list-modules.json
@@ -1,0 +1,46 @@
+{
+	"Path": "github.com/oligot/go-mod-upgrade",
+	"Main": true,
+	"Dir": "/work/member",
+	"GoMod": "/work/member/go.mod",
+	"GoVersion": "1.26.3"
+}
+{
+	"Path": "github.com/AlecAivazis/survey/v2",
+	"Version": "v2.3.7",
+	"Time": "2022-12-08T15:41:06Z",
+	"Update": {
+		"Path": "github.com/AlecAivazis/survey/v2",
+		"Version": "v2.3.8",
+		"Time": "2024-02-01T10:00:00Z"
+	}
+}
+{
+	"Path": "github.com/Masterminds/semver/v3",
+	"Version": "v3.5.0",
+	"Update": {
+		"Path": "github.com/Masterminds/semver/v3",
+		"Version": "v3.6.0"
+	}
+}
+{
+	"Path": "github.com/mattn/go-isatty",
+	"Version": "v0.0.20",
+	"Indirect": true,
+	"Update": {
+		"Path": "github.com/mattn/go-isatty",
+		"Version": "v0.0.21"
+	}
+}
+{
+	"Path": "github.com/apex/log",
+	"Version": "v1.9.0",
+	"Update": {
+		"Path": "github.com/apex/log",
+		"Version": "v1.9.1"
+	}
+}
+{
+	"Path": "golang.org/x/mod",
+	"Version": "v0.36.0"
+}

--- a/internal/discover/testdata/list-tools.txt
+++ b/internal/discover/testdata/list-tools.txt
@@ -1,0 +1,3 @@
+example.com/cmd/tool v1.2.0
+localonly
+example.com/other/tool v0.4.1

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -22,6 +22,16 @@ type Module struct {
 	To   *semver.Version
 }
 
+// MaxWidths returns the width of the longest module name and of the longest
+// current version, for padding the columns the formatters produce.
+func MaxWidths(modules []Module) (name, from int) {
+	for _, mod := range modules {
+		name = max(name, len(mod.Name))
+		from = max(from, len(mod.From.String()))
+	}
+	return name, from
+}
+
 func (mod *Module) FormatName(length int) string {
 	c := color.New(color.FgWhite).SprintFunc()
 	from := mod.From

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -1,0 +1,162 @@
+package module
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/fatih/color"
+)
+
+// mod builds a Module from version strings, failing the test on bad input.
+func mod(t *testing.T, name, from, to string) Module {
+	t.Helper()
+	fromVersion, err := semver.NewVersion(from)
+	if err != nil {
+		t.Fatalf("bad from version %q: %v", from, err)
+	}
+	toVersion, err := semver.NewVersion(to)
+	if err != nil {
+		t.Fatalf("bad to version %q: %v", to, err)
+	}
+	return Module{Name: name, From: fromVersion, To: toVersion}
+}
+
+func TestPadRight(t *testing.T) {
+	if got := padRight("ab", 5); got != "ab   " {
+		t.Errorf("padRight(%q, 5) = %q, want %q", "ab", got, "ab   ")
+	}
+	if got := padRight("abcdef", 3); got != "abcdef" {
+		t.Errorf("padRight(%q, 3) = %q, want it returned unchanged", "abcdef", got)
+	}
+}
+
+func TestMaxWidths(t *testing.T) {
+	tests := []struct {
+		name     string
+		modules  func(t *testing.T) []Module
+		wantName int
+		wantFrom int
+	}{
+		{
+			name:    "no modules",
+			modules: func(t *testing.T) []Module { return nil },
+		},
+		{
+			name: "widest name and widest version come from different modules",
+			modules: func(t *testing.T) []Module {
+				return []Module{
+					mod(t, "github.com/a/very/long/name", "1.0.0", "1.0.1"),
+					mod(t, "short", "10.20.30", "10.20.31"),
+				}
+			},
+			wantName: 27,
+			wantFrom: 8,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, from := MaxWidths(tt.modules(t))
+			if name != tt.wantName {
+				t.Errorf("name width = %d, want %d", name, tt.wantName)
+			}
+			if from != tt.wantFrom {
+				t.Errorf("from width = %d, want %d", from, tt.wantFrom)
+			}
+		})
+	}
+}
+
+func TestFormatName(t *testing.T) {
+	// fatih/color drops the escape codes when stdout is not a TTY, which is
+	// exactly the case under `go test`. Without this the assertions below
+	// would compare bare strings and pin nothing.
+	color.NoColor = false
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want string
+	}{
+		// A zero major wins over every other branch: this is a minor bump,
+		// but it renders red rather than yellow.
+		{name: "zero major beats a minor bump", from: "0.1.0", to: "0.2.0", want: "\x1b[31ma   \x1b[0m"},
+		{name: "minor bump is yellow", from: "1.2.3", to: "1.3.0", want: "\x1b[33ma   \x1b[0m"},
+		{name: "patch bump is green", from: "1.2.3", to: "1.2.4", want: "\x1b[32ma   \x1b[0m"},
+		{name: "no change is white", from: "1.2.3", to: "1.2.3", want: "\x1b[37ma   \x1b[0m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mod(t, "a", tt.from, tt.to)
+			if got := m.FormatName(4); got != tt.want {
+				t.Errorf("FormatName(4) = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatFrom(t *testing.T) {
+	color.NoColor = false
+
+	m := mod(t, "a", "1.2.3", "1.2.4")
+	if got, want := m.FormatFrom(8), "\x1b[34m1.2.3   \x1b[0m"; got != want {
+		t.Errorf("FormatFrom(8) = %q, want %q", got, want)
+	}
+	// Padding never truncates: the version is longer than the column.
+	long := mod(t, "a", "1.2.3-alpha", "1.2.3-beta")
+	if got, want := long.FormatFrom(8), "\x1b[34m1.2.3-alpha\x1b[0m"; got != want {
+		t.Errorf("FormatFrom(8) = %q, want %q", got, want)
+	}
+}
+
+func TestFormatTo(t *testing.T) {
+	color.NoColor = false
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want string
+	}{
+		{
+			name: "patch bump greens only the patch",
+			from: "1.2.3", to: "1.2.4",
+			want: "1.2.\x1b[32m4\x1b[0m",
+		},
+		{
+			name: "minor bump greens the minor, its dot, and the patch",
+			from: "1.2.3", to: "1.3.0",
+			want: "1.\x1b[32m3\x1b[0m\x1b[32m.\x1b[0m\x1b[32m0\x1b[0m",
+		},
+		{
+			// The `same` flag is already false once the minor differs, so the
+			// patch greens even though its value did not change.
+			name: "minor changes and patch does not: patch still greens",
+			from: "1.2.3", to: "1.3.3",
+			want: "1.\x1b[32m3\x1b[0m\x1b[32m.\x1b[0m\x1b[32m3\x1b[0m",
+		},
+		{
+			name: "no change greens nothing",
+			from: "1.2.3", to: "1.2.3",
+			want: "1.2.3",
+		},
+		{
+			name: "prerelease change greens the prerelease, not the dash",
+			from: "1.2.3-alpha", to: "1.2.3-beta",
+			want: "1.2.3-\x1b[32mbeta\x1b[0m",
+		},
+		{
+			name: "metadata greens the plus and the metadata",
+			from: "1.2.3", to: "1.2.4+meta",
+			want: "1.2.\x1b[32m4\x1b[0m\x1b[32m+\x1b[0m\x1b[32mmeta\x1b[0m",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := mod(t, "a", tt.from, tt.to)
+			if got := m.FormatTo(); got != tt.want {
+				t.Errorf("FormatTo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -1,0 +1,57 @@
+// Package prompt asks the user which modules to update.
+package prompt
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+	term "github.com/AlecAivazis/survey/v2/terminal"
+
+	"github.com/oligot/go-mod-upgrade/internal/module"
+)
+
+// ErrAborted is returned when the user interrupts the selection with ctrl+c.
+// It exists so callers can recognise an interrupt without importing survey.
+var ErrAborted = errors.New("selection aborted")
+
+// multiSelect doesn't show the answer. It just resets the prompt, and the
+// answers are shown afterwards.
+type multiSelect struct {
+	survey.MultiSelect
+}
+
+func (m multiSelect) Cleanup(config *survey.PromptConfig, val any) error {
+	return m.Render("", nil)
+}
+
+// Choose asks the user which modules to update. The selected modules keep the
+// order they were passed in.
+func Choose(modules []module.Module, pageSize int) ([]module.Module, error) {
+	maxName, maxFrom := module.MaxWidths(modules)
+	options := []string{}
+	for _, x := range modules {
+		from := x.FormatFrom(maxFrom)
+		option := fmt.Sprintf("%s %s -> %s", x.FormatName(maxName), from, x.FormatTo())
+		options = append(options, option)
+	}
+	prompt := &multiSelect{
+		survey.MultiSelect{
+			Message:  "Choose which modules to update",
+			Options:  options,
+			PageSize: pageSize,
+		},
+	}
+	choice := []int{}
+	if err := survey.AskOne(prompt, &choice); err != nil {
+		if errors.Is(err, term.InterruptErr) {
+			return nil, ErrAborted
+		}
+		return nil, fmt.Errorf("choosing modules: %w", err)
+	}
+	updates := []module.Module{}
+	for _, x := range choice {
+		updates = append(updates, modules[x])
+	}
+	return updates, nil
+}

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,15 @@ GLOBAL OPTIONS:
    --version                   print the version (default: false)
 ```
 
+> **Breaking change since v0.13.0:** `--ignore` values are treated as regular
+> expressions, matching the flag's documented behaviour. They used to be
+> matched as plain substrings, so a value containing a regex metacharacter now
+> means something different. An unanchored pattern such as `apex` still
+> matches anywhere in the module path; anchor it with `^…$` to match a whole
+> path. An invalid pattern is now a hard error — the command reports it and
+> exits non-zero before doing any work, where a substring never could be
+> invalid.
+
 ## Integration
 
 You may also use go-mod-upgrade with these tools:


### PR DESCRIPTION
Three feature branches are in flight and all three rewrite the same 425-line function in internal/app/app.go. Each had reached for a seam only far enough to test its own feature, so the same concerns had three different local solutions and merging in any order would lose two thirds of the improvements or re-litigate them. Extract the seams all three need onto main instead, so they rebase onto shared ground rather than onto each other.

internal/discover owns go list invocation, parsing and ignore filtering behind a Runner func type; internal/prompt hides the TUI library behind Choose/ErrAborted, whose signature matches what the huh branch already arrived at, making its rebase an internals swap. app.go keeps orchestration only.

os.Chdir is gone: cmd.Dir replaces it at all three cwd-sensitive call sites, which also fixes a latent landmine, since the loop only chdir'd back on the success path, and makes discovery safe to call concurrently. The repository had zero test files; characterization tests landed before the structure moved and now cover formatting, parsing and argument construction.

Four fixes ride along that each unblock a specific branch: -json discovery replaces a quoted template and its regex, update returns errors instead of calling os.Exit, go get drops its deprecated -d flag, and a guard that was dead twice over is deleted.

The tool-support check stays inside the workspace loop, as Discoverer.ToolsSupported. Hoisting it out of the loop looks safe but is not: go version selects its toolchain from the go.mod of the directory it runs in, so a single answer for the whole workspace would let a member pinning a pre-1.24 toolchain reach `go list tool`, where tool is not yet a meta-pattern. That error propagates and aborts the entire walk, where asking per directory merely skips that one member's tools.

BREAKING CHANGE: --ignore values are compiled as regular expressions instead of matched as plain substrings. Both the readme and the flag's own usage string already promised regular expressions, so this closes the gap between the documentation and the code, but a value containing a metacharacter now means something different and an invalid pattern is now a hard error. Unanchored patterns keep matching anywhere in the module path.